### PR TITLE
[#2] Lot Engine timeline + chart consumer + Node test harness

### DIFF
--- a/hyperwheel.html
+++ b/hyperwheel.html
@@ -1351,6 +1351,7 @@ function lotEngine(assetTrades) {
 
   const lots = [];
   const tradeAccounting = {};
+  const timeline = [];
 
   sorted.forEach(t => {
     const cc = t.closeCost || 0;
@@ -1439,10 +1440,27 @@ function lotEngine(assetTrades) {
       runningPnl: portfolioPnl,
       runningPremiums: portfolioPremiums,
     };
+
+    // Append timeline snapshot (one per processed trade)
+    timeline.push({ date: t.date, runningPnl: portfolioPnl, runningPremiums: portfolioPremiums });
   });
 
-  return { lots, portfolioPnl, portfolioPremiums, putOnlyPnl, tradeAccounting };
+  return { lots, portfolioPnl, portfolioPremiums, putOnlyPnl, tradeAccounting, timeline };
 }
+
+// Node export for tests
+if (typeof module !== 'undefined') module.exports = { lotEngine };
+
+// ── LOT NET COST HELPERS ─────────────────────────────────────
+
+function lotNetCost(lotSize, lotCostBasis, lotPremiums) {
+  // size === 0 guard returns null
+  if (!lotSize || lotSize === 0) return null;
+  return lotCostBasis - (lotPremiums / lotSize);
+}
+
+// Node export for tests
+if (typeof module !== 'undefined') module.exports = { lotNetCost };
 
 // ── COMPUTE ──────────────────────────────────────────────────
 // Orchestrator: per-asset, runs the lot engine then enriches each
@@ -1458,12 +1476,14 @@ function compute(assetFilter) {
   const assets = ['BTC', 'ETH', 'HYPE', 'SOL'];
   const streams = {};
   const lots = {};
+  const engines = {};
 
   assets.forEach(a => {
     const assetTrades = trades.filter(t => t.asset === a)
       .sort((x, y) => x.date.localeCompare(y.date) || x.id - y.id);
 
     const engine = lotEngine(assetTrades);
+    engines[a] = engine;
     lots[a] = engine.lots;
     const openNow = engine.lots.find(l => l.open);
 
@@ -1475,7 +1495,7 @@ function compute(assetFilter) {
 
       let nc = null, lotNum = null, lotSize = null, lotCostBasis = null;
       if (snap) {
-        nc = snap.lotCostBasis - (snap.lotPremiums / snap.lotSize);
+        nc = lotNetCost(snap.lotSize, snap.lotCostBasis, snap.lotPremiums);
         lotNum = snap.lotNum;
         lotSize = snap.lotSize;
         lotCostBasis = snap.lotCostBasis;
@@ -1503,6 +1523,29 @@ function compute(assetFilter) {
     streams[a] = enriched;
   });
 
+  // Build combined timeline from per-asset engines (one snapshot per processed trade)
+  const events = [];
+  assets.forEach(a => {
+    const eng = engines[a];
+    if (!eng || !eng.timeline) return;
+    let prevPnl = 0, prevPrem = 0;
+    eng.timeline.forEach(entry => {
+      const dPnl = entry.runningPnl - prevPnl;
+      const dPrem = entry.runningPremiums - prevPrem;
+      events.push({ date: entry.date, dPnl, dPrem });
+      prevPnl = entry.runningPnl;
+      prevPrem = entry.runningPremiums;
+    });
+  });
+  events.sort((x, y) => x.date.localeCompare(y.date));
+  let runningPnl = 0, runningPremiums = 0;
+  const timeline = [];
+  events.forEach(e => {
+    runningPnl += e.dPnl;
+    runningPremiums += e.dPrem;
+    timeline.push({ date: e.date, runningPnl, runningPremiums });
+  });
+
   let allRows = [];
   assets.forEach(a => streams[a].forEach(r => allRows.push(r)));
   allRows.sort((a, b) => {
@@ -1518,7 +1561,7 @@ function compute(assetFilter) {
     ? allRows.filter(r => r.asset === assetFilter)
     : allRows;
 
-  return { streams, lots, allRows, displayRows };
+  return { streams, lots, allRows, displayRows, timeline };
 }
 
 // Sort state — persists across renders
@@ -1995,25 +2038,15 @@ function setCpnlPeriod(p) {
     const b = document.getElementById('cpnl-btn-' + x);
     if (b) b.classList.toggle('active', x === p);
   });
-  rCpnlChart();
+  rCpnlChart(typeof window !== 'undefined' ? window.__cpnlTimeline : undefined);
 }
 
-function rCpnlChart() {
+function rCpnlChart(timeline) {
   const area = document.getElementById('cpnl-chart-area');
   if (!area) return;
 
-  // Build time series from all non-HOLDING trades
-  const events = [];
-  trades.forEach(t => {
-    if (t.type === 'HOLDING') return;
-    const eventDate = t.outcome === 'OPEN' ? t.date : t.expiry;
-    if (!eventDate) return;
-    const prem = (t.premium || 0) - (t.closeCost || 0);
-    events.push({ date: eventDate, prem });
-  });
-  events.sort((a, b) => a.date.localeCompare(b.date));
-
-  if (!events.length) {
+  // Use provided timeline (from compute) if available
+  if (!timeline || !timeline.length) {
     area.innerHTML = '<div class="cpnl-empty"><span style="font-size:1.6rem;opacity:.3">&#9196;</span>No trades yet</div>';
     const vEl = document.getElementById('cpnl-val');
     if (vEl) vEl.textContent = '—';
@@ -2021,6 +2054,16 @@ function rCpnlChart() {
     if (cEl) cEl.innerHTML = '';
     return;
   }
+
+  // Build cumulative series from timeline (timeline entries are date-ordered snapshots)
+  const allSeries = [{ date: timeline[0].date, val: 0 }];
+  timeline.forEach(e => {
+    const val = e.runningPremiums;
+    const last = allSeries[allSeries.length - 1];
+    if (last.date === e.date) { last.val = val; }
+    else { allSeries.push({ date: e.date, val }); }
+  });
+  const totalPnl = allSeries.length ? allSeries[allSeries.length - 1].val : 0;
 
   // Period filter cutoff
   const today = new Date();
@@ -2030,17 +2073,6 @@ function rCpnlChart() {
   } else if (sCpnlPeriod === '3M') {
     cutoff = new Date(today); cutoff.setDate(cutoff.getDate() - 90);
   }
-
-  // Build cumulative series for ALL time first (for total shown in header)
-  let runAll = 0;
-  const allSeries = [{ date: events[0].date, val: 0 }];
-  events.forEach(e => {
-    runAll += e.prem;
-    const last = allSeries[allSeries.length - 1];
-    if (last.date === e.date) { last.val = runAll; }
-    else { allSeries.push({ date: e.date, val: runAll }); }
-  });
-  const totalPnl = runAll;
 
   // Filter series for display period
   let dispSeries;
@@ -2481,8 +2513,8 @@ function rCpnlChart() {
   }
 }
 
-function rCharts(displayRows) {
-  rCpnlChart();
+function rCharts(displayRows, timeline) {
+  rCpnlChart(timeline);
   const el = document.getElementById('ppnl-body');
   if (!el) return;
 
@@ -2632,10 +2664,12 @@ function cOpts(ttFmt, yFmt) {
 
 // ── RENDER
 function render() {
-  const { streams, lots, allRows, displayRows } = compute(sFilter);
+  const { streams, lots, allRows, displayRows, timeline } = compute(sFilter);
   rStats(streams, lots, displayRows);
   rTable(displayRows, streams, lots);
-  rCharts(displayRows);
+  // expose for UI controls that invoke rCpnlChart without args
+  if (typeof window !== 'undefined') window.__cpnlTimeline = timeline;
+  rCharts(displayRows, timeline);
 }
 
 // ── UTILS

--- a/src/js/04b-lot-engine.js
+++ b/src/js/04b-lot-engine.js
@@ -35,6 +35,7 @@ function lotEngine(assetTrades) {
 
   const lots = [];
   const tradeAccounting = {};
+  const timeline = [];
 
   sorted.forEach(t => {
     const cc = t.closeCost || 0;
@@ -123,7 +124,13 @@ function lotEngine(assetTrades) {
       runningPnl: portfolioPnl,
       runningPremiums: portfolioPremiums,
     };
+
+    // Append timeline snapshot (one per processed trade)
+    timeline.push({ date: t.date, runningPnl: portfolioPnl, runningPremiums: portfolioPremiums });
   });
 
-  return { lots, portfolioPnl, portfolioPremiums, putOnlyPnl, tradeAccounting };
+  return { lots, portfolioPnl, portfolioPremiums, putOnlyPnl, tradeAccounting, timeline };
 }
+
+// Node export for tests
+if (typeof module !== 'undefined') module.exports = { lotEngine };

--- a/src/js/04c-lot-netcost.js
+++ b/src/js/04c-lot-netcost.js
@@ -1,0 +1,10 @@
+// ── LOT NET COST HELPERS ─────────────────────────────────────
+
+function lotNetCost(lotSize, lotCostBasis, lotPremiums) {
+  // size === 0 guard returns null
+  if (!lotSize || lotSize === 0) return null;
+  return lotCostBasis - (lotPremiums / lotSize);
+}
+
+// Node export for tests
+if (typeof module !== 'undefined') module.exports = { lotNetCost };

--- a/src/js/05-compute.js
+++ b/src/js/05-compute.js
@@ -12,12 +12,14 @@ function compute(assetFilter) {
   const assets = ['BTC', 'ETH', 'HYPE', 'SOL'];
   const streams = {};
   const lots = {};
+  const engines = {};
 
   assets.forEach(a => {
     const assetTrades = trades.filter(t => t.asset === a)
       .sort((x, y) => x.date.localeCompare(y.date) || x.id - y.id);
 
     const engine = lotEngine(assetTrades);
+    engines[a] = engine;
     lots[a] = engine.lots;
     const openNow = engine.lots.find(l => l.open);
 
@@ -29,7 +31,7 @@ function compute(assetFilter) {
 
       let nc = null, lotNum = null, lotSize = null, lotCostBasis = null;
       if (snap) {
-        nc = snap.lotCostBasis - (snap.lotPremiums / snap.lotSize);
+        nc = lotNetCost(snap.lotSize, snap.lotCostBasis, snap.lotPremiums);
         lotNum = snap.lotNum;
         lotSize = snap.lotSize;
         lotCostBasis = snap.lotCostBasis;
@@ -57,6 +59,29 @@ function compute(assetFilter) {
     streams[a] = enriched;
   });
 
+  // Build combined timeline from per-asset engines (one snapshot per processed trade)
+  const events = [];
+  assets.forEach(a => {
+    const eng = engines[a];
+    if (!eng || !eng.timeline) return;
+    let prevPnl = 0, prevPrem = 0;
+    eng.timeline.forEach(entry => {
+      const dPnl = entry.runningPnl - prevPnl;
+      const dPrem = entry.runningPremiums - prevPrem;
+      events.push({ date: entry.date, dPnl, dPrem });
+      prevPnl = entry.runningPnl;
+      prevPrem = entry.runningPremiums;
+    });
+  });
+  events.sort((x, y) => x.date.localeCompare(y.date));
+  let runningPnl = 0, runningPremiums = 0;
+  const timeline = [];
+  events.forEach(e => {
+    runningPnl += e.dPnl;
+    runningPremiums += e.dPrem;
+    timeline.push({ date: e.date, runningPnl, runningPremiums });
+  });
+
   let allRows = [];
   assets.forEach(a => streams[a].forEach(r => allRows.push(r)));
   allRows.sort((a, b) => {
@@ -72,5 +97,5 @@ function compute(assetFilter) {
     ? allRows.filter(r => r.asset === assetFilter)
     : allRows;
 
-  return { streams, lots, allRows, displayRows };
+  return { streams, lots, allRows, displayRows, timeline };
 }

--- a/src/js/07-render-charts.js
+++ b/src/js/07-render-charts.js
@@ -5,25 +5,15 @@ function setCpnlPeriod(p) {
     const b = document.getElementById('cpnl-btn-' + x);
     if (b) b.classList.toggle('active', x === p);
   });
-  rCpnlChart();
+  rCpnlChart(typeof window !== 'undefined' ? window.__cpnlTimeline : undefined);
 }
 
-function rCpnlChart() {
+function rCpnlChart(timeline) {
   const area = document.getElementById('cpnl-chart-area');
   if (!area) return;
 
-  // Build time series from all non-HOLDING trades
-  const events = [];
-  trades.forEach(t => {
-    if (t.type === 'HOLDING') return;
-    const eventDate = t.outcome === 'OPEN' ? t.date : t.expiry;
-    if (!eventDate) return;
-    const prem = (t.premium || 0) - (t.closeCost || 0);
-    events.push({ date: eventDate, prem });
-  });
-  events.sort((a, b) => a.date.localeCompare(b.date));
-
-  if (!events.length) {
+  // Use provided timeline (from compute) if available
+  if (!timeline || !timeline.length) {
     area.innerHTML = '<div class="cpnl-empty"><span style="font-size:1.6rem;opacity:.3">&#9196;</span>No trades yet</div>';
     const vEl = document.getElementById('cpnl-val');
     if (vEl) vEl.textContent = '—';
@@ -31,6 +21,16 @@ function rCpnlChart() {
     if (cEl) cEl.innerHTML = '';
     return;
   }
+
+  // Build cumulative series from timeline (timeline entries are date-ordered snapshots)
+  const allSeries = [{ date: timeline[0].date, val: 0 }];
+  timeline.forEach(e => {
+    const val = e.runningPremiums;
+    const last = allSeries[allSeries.length - 1];
+    if (last.date === e.date) { last.val = val; }
+    else { allSeries.push({ date: e.date, val }); }
+  });
+  const totalPnl = allSeries.length ? allSeries[allSeries.length - 1].val : 0;
 
   // Period filter cutoff
   const today = new Date();
@@ -40,17 +40,6 @@ function rCpnlChart() {
   } else if (sCpnlPeriod === '3M') {
     cutoff = new Date(today); cutoff.setDate(cutoff.getDate() - 90);
   }
-
-  // Build cumulative series for ALL time first (for total shown in header)
-  let runAll = 0;
-  const allSeries = [{ date: events[0].date, val: 0 }];
-  events.forEach(e => {
-    runAll += e.prem;
-    const last = allSeries[allSeries.length - 1];
-    if (last.date === e.date) { last.val = runAll; }
-    else { allSeries.push({ date: e.date, val: runAll }); }
-  });
-  const totalPnl = runAll;
 
   // Filter series for display period
   let dispSeries;
@@ -491,8 +480,8 @@ function rCpnlChart() {
   }
 }
 
-function rCharts(displayRows) {
-  rCpnlChart();
+function rCharts(displayRows, timeline) {
+  rCpnlChart(timeline);
   const el = document.getElementById('ppnl-body');
   if (!el) return;
 

--- a/src/js/08-render.js
+++ b/src/js/08-render.js
@@ -1,7 +1,9 @@
 // ── RENDER
 function render() {
-  const { streams, lots, allRows, displayRows } = compute(sFilter);
+  const { streams, lots, allRows, displayRows, timeline } = compute(sFilter);
   rStats(streams, lots, displayRows);
   rTable(displayRows, streams, lots);
-  rCharts(displayRows);
+  // expose for UI controls that invoke rCpnlChart without args
+  if (typeof window !== 'undefined') window.__cpnlTimeline = timeline;
+  rCharts(displayRows, timeline);
 }

--- a/test/lot-engine.test.js
+++ b/test/lot-engine.test.js
@@ -1,0 +1,42 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { lotEngine } = require('../src/js/04b-lot-engine.js');
+
+// Small trade history exercising HOLDING, ASSIGNED PUT, CALL attach, CALLED
+const trades = [
+  { id: 1, asset: 'BTC', type: 'HOLDING', date: '2026-01-01', strike: 1000, size: 1, premium: 0, outcome: 'OPEN' },
+  { id: 2, asset: 'BTC', type: 'PUT', date: '2026-01-02', strike: 900, size: 1, premium: 50, outcome: 'ASSIGNED' },
+  { id: 3, asset: 'BTC', type: 'CALL', date: '2026-01-03', strike: 1100, size: 1, premium: 20, outcome: 'OPEN', lotNum: 2 },
+  { id: 4, asset: 'BTC', type: 'CALL', date: '2026-01-04', strike: 1200, size: 1, premium: 0, outcome: 'CALLED', lotNum: 2 },
+];
+
+test('lotEngine emits timeline and enforces invariants', () => {
+  const engine = lotEngine(trades);
+
+  // timeline length equals number of trades processed
+  assert.strictEqual(engine.timeline.length, trades.length);
+
+  // timeline is date-ordered
+  for (let i = 1; i < engine.timeline.length; i++) {
+    assert.ok(engine.timeline[i].date >= engine.timeline[i-1].date);
+  }
+
+  // ASSIGNED PUT: lot created with lotPremiums == netPrem (50)
+  const asgSnap = engine.tradeAccounting[2];
+  assert.ok(asgSnap.lot, 'Assigned trade should have opened a lot');
+  assert.strictEqual(asgSnap.lot.lotPremiums, 50);
+  // Running PnL after assignment = netPrem - strike*size
+  assert.strictEqual(asgSnap.runningPnl, 50 - (900 * 1));
+
+  // CALL attach: premium added to lotPremiums
+  const callSnap = engine.tradeAccounting[3];
+  assert.ok(callSnap.lot, 'Call attach should reference a lot');
+  assert.strictEqual(callSnap.lot.lotPremiums, 50 + 20);
+
+  // CALLED: lot size reduced/closed and portfolioPnl credited by strike*calledSize
+  const calledSnap = engine.tradeAccounting[4];
+  // After called, runningPnl should be previous + 1200
+  assert.strictEqual(calledSnap.runningPnl, 370);
+  const lot = engine.lots.find(l => l.lotNum === 2);
+  assert.ok(lot.size === 0 || lot.open === false, 'Lot should be closed or size zero');
+});

--- a/test/lot-netcost.test.js
+++ b/test/lot-netcost.test.js
@@ -1,0 +1,12 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { lotNetCost } = require('../src/js/04c-lot-netcost.js');
+
+test('lotNetCost computes net cost when size > 0', () => {
+  const res = lotNetCost(10, 100, 50);
+  assert.strictEqual(res, 100 - (50 / 10));
+});
+
+test('lotNetCost returns null when size === 0', () => {
+  assert.strictEqual(lotNetCost(0, 100, 50), null);
+});


### PR DESCRIPTION
Add TradeDraft module and migrate form controls to draft-based form rendering\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---
Shrink compute(): lift display fields into renderer

- Remove returnPct, monthly, annual, lotPnl from compute()\n- Compute APR on-demand in renderer via computeAnnualForRow()\n- Update charts and CSV export to compute APR at render time

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---
Merge pull request #8 from heyitsStylez/copilot/issue-5

[#5] Shrink compute() — lift display fields into row renderer
---
Merge pull request #7 from heyitsStylez/copilot/issue-6

[#6] TradeDraft module + form-controls migration + scoped form re-render
---
Implement commitTrades seam and route all CRUD through it

Decisions:
- Introduced commitTrades(mutator) in src/js/02-utils.js to centralise persistence + cloud-push + render.
- The mutator receives the current trades array and may mutate in-place or return a new array; commitTrades then calls save() and render() once.
- Updated all CRUD call sites (add, delete, quick-outcome, edit save, merge confirm, reset) and chain-sync/cloud-pull importers to use commitTrades so batch imports produce one render.

Files changed:
- src/js/02-utils.js
- src/js/04-trade-crud.js
- src/js/13-edit-modal.js
- src/js/14-merge-modal.js
- src/js/10-reset-modal.js
- src/js/18-chain-sync.js
- src/js/12-cloud-sync.js

Blockers/Notes:
- None

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---
Merge pull request #9 from heyitsStylez/copilot/issue-4

[#4] commitTrades write seam + migrate all CRUD callers (incl. chain-sync batching)
---
Emit timeline from lotEngine; add lotNetCost helper; charts consume timeline; Node tests\n\nDecisions:\n- Emit per-trade timeline from lotEngine (date-ordered snapshots)\n- compute() aggregates per-asset timelines into a portfolio timeline consumed by charts\n- rCpnlChart consumes timeline instead of walking trades; window.__cpnlTimeline exposed for UI controls\n- Introduced lotNetCost helper and added Node export footers for testability\n\nFiles changed:\n- src/js/04b-lot-engine.js\- src/js/04c-lot-netcost.js\- src/js/05-compute.js\- src/js/07-render-charts.js\- src/js/08-render.js\- test/lot-netcost.test.js\- test/lot-engine.test.js\n\nBlockers/notes:\n- None\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>