### PR TITLE
Rename wallet popup button: Connect → Track Wallet

### DIFF
--- a/src/html/body.html
+++ b/src/html/body.html
@@ -10,7 +10,7 @@
         spellcheck="false" autocomplete="off"
         oninput="document.getElementById('wp-enter-btn').disabled=!this.value.trim().startsWith('0x')">
     </div>
-    <button id="wp-enter-btn" class="wp-btn" onclick="submitWalletPopup()" disabled>[ Connect ]</button>
+    <button id="wp-enter-btn" class="wp-btn" onclick="submitWalletPopup()" disabled>[ Track Wallet ]</button>
     <div id="wp-status" class="wp-status"><span class="wp-cursor"></span>awaiting input...</div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Replace `[ Connect ]` with `[ Track Wallet ]` in the first-visit wallet popup (`src/html/body.html:13`)
- "Track" accurately describes the read-only address flow (no provider connection)

Closes #18

## Test plan
- [x] `python3 build.py --check` passes
- [x] `npm test` passes (23/23)
- [ ] Manual smoke: load built HTML with cleared localStorage, confirm popup button reads `[ Track Wallet ]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)