### PR TITLE
Add label-driven auto-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Get PR labels for merge commit
+        id: labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=$(gh pr list --state merged --search "${{ github.sha }}" --json number,labels --jq '.[0]')
+          if [ -z "$PR" ] || [ "$PR" = "null" ]; then
+            echo "labels=" >> "$GITHUB_OUTPUT"
+          else
+            LABELS=$(echo "$PR" | jq -r '.labels | map(.name) | join(",")')
+            echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get current tag
+        id: current
+        run: |
+          TAG=$(git tag --list 'v*.*.*' --sort=-v:refname | head -n1)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version
+        id: next
+        run: |
+          NEXT=$(node scripts/bump-version.js "${{ steps.current.outputs.tag }}" "${{ steps.labels.outputs.labels }}")
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Computed: $NEXT (from tag=${{ steps.current.outputs.tag }}, labels=${{ steps.labels.outputs.labels }})"
+
+      - name: Tag and release
+        if: steps.next.outputs.version != 'skip'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.next.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          gh release create "$VERSION" --generate-notes

--- a/docs/agents/release-labels.md
+++ b/docs/agents/release-labels.md
@@ -1,0 +1,23 @@
+# Release labels
+
+Auto-release runs on every push to `main` (`.github/workflows/release.yml`). The
+workflow looks at the labels on the merged PR and decides what to do:
+
+| Label           | Effect                                              |
+|-----------------|-----------------------------------------------------|
+| `release:skip`  | No tag, no release. Use for docs / infra-only PRs   |
+| `release:major` | Major bump: `vX.Y.Z` → `vX+1.0.0`                   |
+| `release:minor` | Minor bump: `vX.Y.Z` → `vX.Y+1.0`                   |
+| _(none)_        | Patch bump: `vX.Y.Z` → `vX.Y.Z+1` (default)         |
+
+**Precedence** when multiple are present: `skip` > `major` > `minor` > patch.
+
+**First run** (no existing `vX.Y.Z` tags): treated as a base of `v1.0.0`, so a
+default-labelled merge produces `v1.0.1`, `release:minor` produces `v1.1.0`, etc.
+
+## Logic location
+
+The pure version-bump function is `scripts/bump-version.js` (also runnable as a
+CLI: `node scripts/bump-version.js <current-tag> <comma-separated-labels>`).
+Tested in `test/unit/bump-version.test.js`. The workflow YAML just plumbs PR
+labels and the latest tag into it.

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,16 @@
+function nextVersion(currentTag, labels) {
+  if (labels.includes('release:skip')) return 'skip';
+  const m = currentTag ? /^v(\d+)\.(\d+)\.(\d+)$/.exec(currentTag) : null;
+  const [major, minor, patch] = m ? [+m[1], +m[2], +m[3]] : [1, 0, 0];
+  if (labels.includes('release:major')) return `v${major + 1}.0.0`;
+  if (labels.includes('release:minor')) return `v${major}.${minor + 1}.0`;
+  return `v${major}.${minor}.${patch + 1}`;
+}
+
+module.exports = { nextVersion };
+
+if (require.main === module) {
+  const [currentTag, labelsCsv] = process.argv.slice(2);
+  const labels = labelsCsv ? labelsCsv.split(',').map(s => s.trim()).filter(Boolean) : [];
+  process.stdout.write(nextVersion(currentTag || '', labels));
+}

--- a/test/unit/bump-version.test.js
+++ b/test/unit/bump-version.test.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { nextVersion } = require('../../scripts/bump-version.js');
+
+test('release:skip → skip', () => {
+  assert.equal(nextVersion('v1.2.3', ['release:skip']), 'skip');
+});
+
+test('no bump label → patch bump', () => {
+  assert.equal(nextVersion('v1.2.3', []), 'v1.2.4');
+});
+
+test('unrelated labels → patch bump', () => {
+  assert.equal(nextVersion('v0.0.0', ['bug', 'docs']), 'v0.0.1');
+});
+
+test('release:minor → minor bump, patch reset', () => {
+  assert.equal(nextVersion('v1.2.3', ['release:minor']), 'v1.3.0');
+});
+
+test('release:major → major bump, minor + patch reset', () => {
+  assert.equal(nextVersion('v1.2.3', ['release:major']), 'v2.0.0');
+});
+
+test('precedence: skip beats major', () => {
+  assert.equal(nextVersion('v1.2.3', ['release:major', 'release:skip']), 'skip');
+});
+
+test('precedence: major beats minor', () => {
+  assert.equal(nextVersion('v1.2.3', ['release:minor', 'release:major']), 'v2.0.0');
+});
+
+test('precedence: minor beats patch (default)', () => {
+  assert.equal(nextVersion('v1.2.3', ['release:minor', 'bug']), 'v1.3.0');
+});
+
+test('no existing tag (empty) → seed at v1.0.0, patch bump → v1.0.1', () => {
+  assert.equal(nextVersion('', []), 'v1.0.1');
+});
+
+test('no existing tag (null) → v1.0.1 on default bump', () => {
+  assert.equal(nextVersion(null, []), 'v1.0.1');
+});
+
+test('no existing tag + release:minor → v1.1.0', () => {
+  assert.equal(nextVersion('', ['release:minor']), 'v1.1.0');
+});
+
+test('no existing tag + release:skip → skip', () => {
+  assert.equal(nextVersion('', ['release:skip']), 'skip');
+});


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml`: on push to `main`, reads the merged PR's labels and tags + releases accordingly. `release:skip` exits, `release:major`/`release:minor` bump respectively, anything else patch-bumps. Precedence: `skip > major > minor > patch`.
- Pure version-bump logic is `scripts/bump-version.js` (12 unit tests in `test/unit/bump-version.test.js`, built TDD red→green per case). The workflow just plumbs PR labels and the latest git tag into it.
- Created the three labels on the repo (`release:major`, `release:minor`, `release:skip`).
- Documented in `docs/agents/release-labels.md`.

Closes #19.

## Note on this PR's own label
The workflow goes live the moment this merges, so this PR's label determines the **first** auto-release. I've tagged it `release:minor` (new feature, first run → `v1.1.0`). Swap to `release:skip` if you'd rather seed manually, or leave default for `v1.0.1`.

## Test plan
- [x] `npm test` — 35/35 green (12 new for bump-version)
- [x] `python3 build.py --check` — clean
- [x] CLI smoke: `node scripts/bump-version.js v1.2.3 release:minor,bug` → `v1.3.0`
- [ ] **End-to-end (post-merge)**: confirm a tag + GitHub Release appear, and the deployed footer shows the new version (per #17)
- [ ] Follow-up verification merges with `release:skip` (no tag) and a default-labelled PR (patch bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)