### PR TITLE
Disable Vercel auto-deploys on main; rely on deploy hook

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,10 @@
 {
   "buildCommand": "git fetch --tags --depth=1 origin || true; python3 build.py --check",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then git fetch --tags --depth=1 origin >/dev/null 2>&1 || true; ! git describe --exact-match --tags HEAD >/dev/null 2>&1; else exit 1; fi",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  },
   "outputDirectory": "public",
   "framework": null,
   "headers": [


### PR DESCRIPTION
## Summary
- Replace `ignoreCommand` with Vercel's `git.deploymentEnabled.main: false` flag.
- Vercel will no longer auto-deploy on push to `main`. The deploy hook fired by `release.yml` (after tag push) becomes the only production path.

## Why
Last attempt's `ignoreCommand` canceled both the auto-deploy AND the hook-triggered deploy for `be43569` — `git describe --exact-match --tags HEAD` doesn't resolve reliably in Vercel's shallow clone, so even after the tag was pushed, the check returned "ignore". `git.deploymentEnabled` is Vercel's official way to suppress auto-deploys for a branch and is bypassed by deploy hooks, removing the race entirely.

## Test plan
- [x] Merge this PR; confirm Vercel does NOT create a deployment for the merge commit.
- [ ] Confirm `release` workflow tags + hits deploy hook.
- [ ] New deployment for the tagged commit appears in Vercel and reaches Ready.
- [ ] Footer + Track Wallet popup show `vX.Y.Z` (not a SHA).
- [ ] Open a PR from a feature branch; preview deploy still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)