### PR TITLE
Resolve version via ls-remote when local tag refs are missing

### DIFF
--- a/build.py
+++ b/build.py
@@ -31,23 +31,50 @@ def read(path):
         return f.read()
 
 
+def _git(args, cwd):
+    try:
+        result = subprocess.run(
+            ['git', *args], cwd=cwd, capture_output=True, text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _tag_at_head_via_ls_remote(cwd):
+    head = _git(['rev-parse', 'HEAD'], cwd)
+    refs = _git(['ls-remote', '--tags', 'origin'], cwd)
+    if not head or not refs:
+        return None
+    for line in refs.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] == head:
+            name = parts[1].replace('refs/tags/', '').replace('^{}', '')
+            if name:
+                return name
+    return None
+
+
 def resolve_version(cwd=BASE):
     """Return git-tag version string for the repo at *cwd*.
 
     Order of preference:
-      1. ``git describe --tags --always`` (tag, or short SHA if no tag).
-      2. ``unknown`` if git is unavailable or *cwd* is not a repo.
+      1. Local exact-match tag at HEAD (``git describe --exact-match --tags``).
+      2. Remote tag at HEAD via ``git ls-remote`` — fallback for shallow CI
+         clones where local tag refs aren't connected to HEAD.
+      3. ``git describe --tags --always`` (describe-with-distance or short SHA).
+      4. ``unknown`` if git is unavailable or *cwd* is not a repo.
     """
-    try:
-        result = subprocess.run(
-            ['git', 'describe', '--tags', '--always'],
-            cwd=cwd, capture_output=True, text=True,
-        )
-    except (FileNotFoundError, OSError):
-        return 'unknown'
-    if result.returncode != 0:
-        return 'unknown'
-    return result.stdout.strip() or 'unknown'
+    tag = _git(['describe', '--exact-match', '--tags', 'HEAD'], cwd)
+    if tag:
+        return tag
+    tag = _tag_at_head_via_ls_remote(cwd)
+    if tag:
+        return tag
+    described = _git(['describe', '--tags', '--always'], cwd)
+    return described or 'unknown'
 
 
 def build():

--- a/test/build/test_resolve_version.py
+++ b/test/build/test_resolve_version.py
@@ -75,6 +75,30 @@ class ResolveVersionTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             self.assertEqual(build.resolve_version(d), 'unknown')
 
+    def test_ls_remote_fallback_when_local_tag_refs_missing(self):
+        # Vercel-like failure mode: HEAD is at a tagged commit on origin,
+        # but local tag refs aren't populated (shallow clone quirks). The
+        # ls-remote fallback should still surface the tag.
+        with tempfile.TemporaryDirectory() as remote, \
+             tempfile.TemporaryDirectory() as clone:
+            init_repo(remote)
+            git(remote, 'tag', 'v9.9.9')
+            git(remote, 'config', 'receive.denyCurrentBranch', 'ignore')
+            git(clone, 'clone', '--depth=1', remote, '.')
+            # Strip local tag refs to simulate missing-tag-locally state
+            for entry in os.listdir(os.path.join(clone, '.git', 'refs', 'tags')):
+                os.remove(os.path.join(clone, '.git', 'refs', 'tags', entry))
+            packed = os.path.join(clone, '.git', 'packed-refs')
+            if os.path.exists(packed):
+                with open(packed) as f:
+                    lines = [l for l in f if 'refs/tags/' not in l]
+                with open(packed, 'w') as f:
+                    f.writelines(lines)
+            self.assertIsNone(
+                build._git(['describe', '--exact-match', '--tags', 'HEAD'], clone)
+            )
+            self.assertEqual(build.resolve_version(clone), 'v9.9.9')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- `resolve_version()` now tries local `git describe --exact-match --tags` first, then falls back to `git ls-remote --tags origin` to find a tag at HEAD, then to `git describe --tags --always`.
- Added a regression test that simulates the Vercel failure mode (tag exists on origin but local tag refs are missing).

## Why
After PR #31 the deploy hook reliably builds the tagged commit, but the footer still showed a SHA (`73bb0dd` for v0.10.6). Vercel's shallow clone plus `git fetch --tags --depth=1` doesn't reliably connect tag refs to HEAD's commit, so `git describe --tags` walked off the end and returned the short SHA. `ls-remote` queries origin directly, so it works regardless of local clone state.

## Test plan
- [x] `python3 -m unittest discover -s test/build` (6 tests pass).
- [x] `python3 build.py --check` clean.
- [ ] After merge, footer + Track Wallet popup show the new `vX.Y.Z` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)