### PR TITLE
Fix: outcome treemap min-width so small cells stay readable

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -760,7 +760,7 @@ td.td-act { width:1px; white-space:nowrap; padding-right:12px; }
 .outchart-meta{display:flex;justify-content:space-between;align-items:baseline;font-size:.55rem;letter-spacing:1.2px;color:var(--mu);text-transform:uppercase;margin-bottom:8px}
 .outchart-meta b{color:var(--text);font-size:.85rem;font-weight:700;letter-spacing:0;text-transform:none;font-variant-numeric:tabular-nums}
 .outchart-treemap{display:flex;width:100%;height:140px;border:1px solid var(--bd2);background:var(--s2);overflow:hidden;gap:2px}
-.outchart-cell{display:flex;flex-direction:column;justify-content:center;align-items:center;cursor:pointer;color:var(--bg);font-weight:700;transition:filter .15s,opacity .15s;padding:8px;overflow:hidden;text-align:center;min-width:0}
+.outchart-cell{display:flex;flex-direction:column;justify-content:center;align-items:center;cursor:pointer;color:var(--bg);font-weight:700;transition:filter .15s,opacity .15s;padding:8px;overflow:hidden;text-align:center;min-width:110px}
 .outchart-cell:hover{filter:brightness(1.15)}
 .outchart-cell.active{outline:2px solid var(--text);outline-offset:-2px}
 .outchart-cell.dim{opacity:.45}


### PR DESCRIPTION
## Summary
- When one outcome dominated (e.g. 28 EXPIRED vs 1 ASSIGNED/CLOSED), small cells got crushed to ~30px and labels truncated to "ASS…" / "CLO…".
- Set \`.outchart-cell { min-width: 110px }\` so each cell reserves room for its label, count, and premium while EXPIRED still visually dominates.

## Test plan
- [x] \`python3 build.py --check\` passes
- [x] \`npm test\` — 72/72 pass
- [ ] Visual: small ASSIGNED/CLOSED cells now show full label + count + premium

🤖 Generated with [Claude Code](https://claude.com/claude-code)