### PR TITLE
Add husky pre-commit hook running build + tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npm run build
+npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,11 @@ as starting anchors, not exact addresses. Re-grep if a function moved.
 6. **Run `npm test` after touching anything covered by tests** (lot engine,
    compute, merge, fmt, addTrade/quickOutcome flows). CI gates on it.
 
+A Husky pre-commit hook (`.husky/pre-commit`) enforces rules 1 and 6 locally
+by running `npm run build` then `npm test` before every commit. Installed
+automatically by `npm install` via the `prepare` script. No Prettier or
+typecheck step — plain JS, no TS.
+
 ---
 
 ## Tests
@@ -111,6 +116,8 @@ as starting anchors, not exact addresses. Re-grep if a function moved.
   stripping — the footer ships into `hyperwheel.html` and is harmless.
 - **CI:** `.github/workflows/test.yml` runs `npm ci && npm test` separately from
   the build job.
+- **Pre-commit:** Husky runs `npm run build && npm test` before every commit.
+  Bypass with `--no-verify` only for WIP stashes — CI will still gate the push.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,22 @@ Tests live under `test/`:
 
 CI runs `npm test` on every push and PR via `.github/workflows/test.yml`.
 
+## Pre-commit hook
+
+Husky is installed as a dev dependency. After `npm install`, the `prepare`
+script wires up `.husky/pre-commit`, which runs:
+
+```bash
+npm run build   # python3 build.py --check
+npm test        # unit + jsdom integration tests
+```
+
+This gates every commit on the same checks CI runs. There is no Prettier or
+typecheck step — the codebase is plain JS with no TypeScript, and formatting
+is enforced by convention rather than tooling. If a commit needs to bypass
+the hook (rare — e.g. a WIP stash), use `git commit --no-verify`, but don't
+push past CI that way.
+
 ## Release labels (maintainers)
 
 PRs can carry one of these labels to control the auto-release version bump:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hyperwheel",
       "version": "0.0.0",
       "devDependencies": {
+        "husky": "^9.1.7",
         "jsdom": "^24.1.0"
       }
     },
@@ -491,6 +492,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "description": "Single-file wheel-strategy options tracker. Tests only — runtime ships zero dependencies.",
   "scripts": {
     "build": "python3 build.py --check",
-    "test": "node --test test/unit/*.test.js test/integration/*.test.js"
+    "test": "node --test test/unit/*.test.js test/integration/*.test.js",
+    "prepare": "husky"
   },
   "devDependencies": {
+    "husky": "^9.1.7",
     "jsdom": "^24.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- Install husky as a devDependency; `prepare` script wires up the hook on `npm install`
- `.husky/pre-commit` runs `npm run build` then `npm test` — same gates as CI
- No Prettier or typecheck step (plain JS, no TS in this repo)
- Update CLAUDE.md and CONTRIBUTING.md to document the hook

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (85 tests)
- [x] Hook fires on commit (this PR's commit ran through it cleanly)
- [ ] Fresh clone + `npm install` installs the hook via `prepare`

🤖 Generated with [Claude Code](https://claude.com/claude-code)