### PR TITLE
Align Expiring This Week table with Trade Log

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -174,6 +174,28 @@ read **Term**. Never label a frozen original-DTE column "DTE" — the
 ambiguity historically led to three identically-labelled columns showing two
 different numbers.
 
+### Premium Statistics
+A gross-premium-income view over a set of Trade rows. Distinct from Realised
+P&L (which is a cash-flow lens): Premium Statistics treats premium collected as
+the primary signal and derives:
+
+- **Total premium** — sum of net premiums across all trades in the set
+- **Total notional** — Σ strike × size (capital at risk)
+- **Portfolio APR** — notional-weighted average APR of settled options:
+  `(netPrem / collateral) / DTE × 365`, weighted by notional
+- **Return rate** — share of settled options that expired OTM (premium kept)
+- **OTM / ITM counts** — settled outcome breakdown
+
+Lives in `src/js/05d-calc-stats.js` as the pure function
+`calcPremiumStats(rows) → { totalPrem, totalNotional, portfolioAPR, returnRate,
+otmCount, itmCount, openCount, settled, totalCount }`. Dual-exported. Consumed
+by `rCharts` for the Premium P&L Total and Monthly tabs.
+
+Intentionally does **not** include Realised P&L or Unrealised P&L — those live
+in `computePnl`. The two functions answer different questions: `computePnl`
+answers *"what did this position earn under cash-flow accounting?"*;
+`calcPremiumStats` answers *"how is the premium-income engine performing?"*
+
 ### Trade accounting snapshot
 A per-trade record of the lot state **at the moment that trade was processed**
 by the engine: `{ lotNum, lotSize, lotPremiums, lotCostBasis }`. Captured

--- a/src/js/06-render-table.js
+++ b/src/js/06-render-table.js
@@ -214,15 +214,15 @@ function renderExpiryTable() {
   const rows = enriched.map(e => {
     const t = e.t;
     return '<tr>'
-      + '<td style="color:var(--' + e.col + ');font-weight:700">' + t.asset + '</td>'
-      + '<td>' + t.type + '</td>'
+      + '<td><span class="badge b' + e.col + '">' + t.asset + '</span></td>'
+      + '<td>' + e.platBadge + '</td>'
+      + '<td><span class="badge b' + t.type.toLowerCase() + '">' + t.type + '</span></td>'
       + '<td>$' + fmt(t.strike) + '</td>'
       + '<td>' + fmt(t.size) + '</td>'
       + '<td>' + e.dteLabel + '</td>'
       + '<td>$' + fmt(t.premium) + '</td>'
       + '<td>' + e.aprHtml + '</td>'
       + '<td>' + e.statusHtml + '</td>'
-      + '<td>' + e.platBadge + '</td>'
       + '<td class="td-act">' + e.actionsHtml + '</td>'
       + '</tr>';
   }).join('');
@@ -248,7 +248,7 @@ function renderExpiryTable() {
   }).join('');
 
   wrap.innerHTML = '<table class="expiry-tbl">'
-    + '<thead><tr><th>Asset</th><th>Strategy</th><th>Strike</th><th>Size</th><th>DTE</th><th>Premium</th><th>APR</th><th>Status</th><th>Platform</th><th></th></tr></thead>'
+    + '<thead><tr><th>Asset</th><th>Platform</th><th>Type</th><th>Strike</th><th>Size</th><th>DTE</th><th>Premium</th><th>APR</th><th>Status</th><th></th></tr></thead>'
     + '<tbody>' + rows + '</tbody>'
     + '</table>'
     + '<div class="exp-cards">' + cards + '</div>';


### PR DESCRIPTION
## Summary
- Column order now matches Open Positions: Asset | Platform | Type | Strike | Size | DTE | Premium | APR | Status | actions
- Asset and Type render as colored badges (was plain text / plain colored text)
- Renames header "Strategy" → "Type" to match Trade Log terminology

## Test plan
- [ ] Expiring This Week table columns align visually with Open Positions columns
- [ ] Asset badge colors match (BTC orange, ETH blue, etc.)
- [ ] PUT badge shows red, CALL badge shows blue/green — consistent with Trade Log
- [ ] Platform badge still appears correctly
- [ ] Mobile card layout unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)