### PR TITLE
Wheeler 2: extract the persistence seam (prefactor)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ globals, and 17-boot.js runs an IIFE last to bootstrap the app.
 |------|------:|-----------------------|
 | `01-state.js` | 18 | `HW_WALLET_KEY`, `HW_HOLDINGS_KEY`, `HW_SYNCED_KEY`, `trades[]`, `sAsset/sType/sFilter/sPlatform/sSizeUnit/sPpnlTab/sCpnlPeriod`, `sHistOutcome/sHistFrom/sHistTo`, `livePrices{}`, `MIN_SIZE`, `ASSET_COLORS`, `mergeAsset` |
 | `01a-outcomes.js` | 32 | `OUTCOMES` registry: per-outcome `{title, badgeClass, platforms}`. Single source of truth for outcome display data + picker membership. Lot-lifecycle effects live in the Lot Engine, not here |
-| `02-utils.js` | 33 | `today()`, `save()` (also kicks `scheduleCloudPush`), `fmt()` (max 2dp), `sk()` (K-abbrev), `loadWallet()`, `saveWallet()`, `toast(msg, kind?)` (`'ok'`/`'err'`/`'info'`). Dual-exports `today/fmt/sk` for Node tests |
+| `02-utils.js` | 33 | `today()`, `save()` (routes trades through the persistence seam `persist()`), `fmt()` (max 2dp), `sk()` (K-abbrev), `loadWallet()`, `saveWallet()`, `toast(msg, kind?)` (`'ok'`/`'err'`/`'info'`). Dual-exports `today/fmt/sk` for Node tests |
 | `03-form-controls.js` | 212 | `setAsset/setType/setPlatform/setSizeUnit/setOut/setFilter/setPpnlTab`, `refreshLotPicker`, `autoFillFromLot`, `autoDTE`, history filters: `setHistOutcome/setHistFrom/setHistTo/clearHistFilters` |
 | `04-trade-crud.js` | 39 | `addTrade()` (HOLDING-only — adds spot from drawer), `clearForm`, `deleteTrade`, `quickOutcome` (fires toasts) |
 | `04b-lot-engine.js` | 140 | `lotNetCost(costBasis, lotPremiums, size)` and `lotEngine(assetTrades)` → `{lots, portfolioPnl, portfolioPremiums, putOnlyPnl, tradeAccounting}`. **Single source of truth** for wheel invariants (see Lot model below). Pure; dual-exported for Node. **Key invariant:** assigned-PUT premium IS credited to the new lot's `lotPremiums` |
@@ -68,12 +68,13 @@ globals, and 17-boot.js runs an IIFE last to bootstrap the app.
 | `09-drawer-modal.js` | 15 | `openTradeDrawer`, `closeTradeDrawer`, `focusForm` |
 | `10-reset-modal.js` | 4 | `showReset`, `closeReset`, `doReset` (wipes `trades`) |
 | `11-wallet-popup.js` | 34 | `showWalletPopup`, `hideWalletPopup`, `submitWalletPopup` (first-visit wallet entry) |
+| `12a-persistence.js` | 23 | **Persistence seam** (crypto impl): `loadTrades(): Promise<Trade[]>`, `persist(trades): Promise<void>`, `currentUserKey(): string`. Core reads/writes trades ONLY through these (async from day one, per #84). Crypto wraps `hw_holdings` + debounced cloud push |
 | `12-cloud-sync.js` | 66 | `_setCloudStatus`, `cloudPush` (debounced via `scheduleCloudPush`), `cloudPull` — pushes/pulls **only HOLDING trades** to `/api/sync` keyed by wallet. Toasts on error and on pull-with-data |
 | `13-edit-modal.js` | 102 | `openEditModal(id)`, `closeEditModal`, `saveEdit` — fields prefixed `ef-` (NOT `e-` despite older docs) |
 | `14-merge-modal.js` | 91 | `openMergeModal(asset)`, `closeMergeModal`, `confirmMerge`. View + confirmation only; merge logic lives in `05a-merge-open-lots.js` |
 | `15-event-listeners.js` | 6 | global keydown (Esc closes modals/drawer) |
 | `16-clock.js` | 20 | UTC clock IIFE for header |
-| `17-boot.js` | 33 | init IIFE: load trades, wallet popup OR `render() + fetchExpiryPrices() + cloudPull → autoLoadChain` |
+| `17-boot.js` | 33 | async init IIFE (exposes `bootReady` promise): `trades = await loadTrades()`, wallet popup OR `render() + fetchExpiryPrices() + cloudPull → autoLoadChain`. Tests await `bootReady` via `setupJsdom` |
 | `18-chain-sync.js` | ~530 | Rysk + Hypersurface chain sync: `autoLoadChain`, `syncRysk`, `syncHypersurface`, `resolveRyskOutcomes`, `resolveHsfcOutcomes`, `fetchRyskExpiryPrices`, `autoDetectOutcomes` (stale-detection only), `migrateCloseTrades`. Routes through `/api/chain-sync` proxy. `hasProxy()` returns false on `file://` |
 | `18b-chain-apply.js` | ~55 | `applyCloseTrade(tradesArray, closeTrade)` → boolean; `applyImportedTrades(tradesArray, openTrades, closeTrades, synced)` → `{added, closedCount, corrected}`. Pure helpers extracted from chain-sync: dedup by txHash, open/close split, close-trade matching, OPEN→EXPIRED correction. Both dual-exported for Node tests |
 

--- a/src/js/core/02-utils.js
+++ b/src/js/core/02-utils.js
@@ -1,7 +1,6 @@
 function today() { return new Date().toISOString().split('T')[0]; }
 function save() {
-  localStorage.setItem(HW_HOLDINGS_KEY, JSON.stringify(trades));
-  if (typeof scheduleCloudPush === 'function') scheduleCloudPush();
+  persist(trades);
 }
 function fmt(n)  { return Number(n).toLocaleString('en', {maximumFractionDigits: 2, minimumFractionDigits: 0}); }
 function sk(v)   { return Math.abs(v) >= 1000 ? (v/1000).toFixed(1).replace(/\.0$/,'')+'K' : fmt(v); }

--- a/src/js/core/17-boot.js
+++ b/src/js/core/17-boot.js
@@ -1,11 +1,9 @@
 // ── BOOT ──────────────────────────────────────────────
-(function init() {
-  // Load all persisted trades from localStorage
-  try {
-    trades = JSON.parse(localStorage.getItem(HW_HOLDINGS_KEY) || '[]');
-  } catch (e) {
-    trades = [];
-  }
+// bootReady resolves once trades are loaded and the first render has run.
+// Tests await it; the browser ignores it.
+var bootReady = (async function init() {
+  // Load all persisted trades through the persistence seam
+  trades = await loadTrades();
 
   // Migration: if hw_synced_v1 has entries but no chain-synced trades were
   // persisted (old save() bug only kept HOLDINGs), the synced set is stale.

--- a/src/js/crypto/12a-persistence.js
+++ b/src/js/crypto/12a-persistence.js
@@ -1,0 +1,25 @@
+// ── PERSISTENCE SEAM (crypto implementation) ─────────────────
+// Core reads and writes trades ONLY through this seam:
+//   loadTrades(): Promise<Trade[]>
+//   persist(trades): Promise<void>
+//   currentUserKey(): string
+// Async from day one (see #84) so a phase-2 server backend can slot
+// in without churning core. A second app can swap this file for its own storage.
+// The crypto implementation wraps hw_holdings (localStorage) + debounced cloud push.
+
+async function loadTrades() {
+  try {
+    return JSON.parse(localStorage.getItem(HW_HOLDINGS_KEY) || '[]');
+  } catch (e) {
+    return [];
+  }
+}
+
+async function persist(t) {
+  localStorage.setItem(HW_HOLDINGS_KEY, JSON.stringify(t));
+  if (typeof scheduleCloudPush === 'function') scheduleCloudPush();
+}
+
+function currentUserKey() {
+  return loadWallet();
+}

--- a/test/helpers/setupJsdom.js
+++ b/test/helpers/setupJsdom.js
@@ -10,7 +10,7 @@ const { loadApp } = require('./loadApp');
 
 const ROOT = path.join(__dirname, '..', '..');
 
-function setupJsdom({ wallet = '0x' + '1'.repeat(40), trades = [] } = {}) {
+async function setupJsdom({ wallet = '0x' + '1'.repeat(40), trades = [] } = {}) {
   const body = fs.readFileSync(path.join(ROOT, 'src', 'html', 'body.html'), 'utf8');
   const modals = fs.readFileSync(path.join(ROOT, 'src', 'html', 'modals.html'), 'utf8');
 
@@ -58,6 +58,11 @@ function setupJsdom({ wallet = '0x' + '1'.repeat(40), trades = [] } = {}) {
   }
 
   loadApp(window);
+
+  // Trades now load through the async persistence seam, so boot completes on a
+  // microtask. Await it here (harness is async) to keep tests' synchronous
+  // "seed trades → act → assert" pattern working.
+  if (window.bootReady) await window.bootReady;
 
   // 16-clock.js sets a setInterval that would keep Node's event loop alive
   // forever. Tests must dispose the window to release timers.

--- a/test/integration/add-trade.test.js
+++ b/test/integration/add-trade.test.js
@@ -2,8 +2,8 @@ const test = require('node:test');
 const assert = require('node:assert');
 const { setupJsdom } = require('../helpers/setupJsdom');
 
-test('addTrade() from drawer pushes a HOLDING and persists to localStorage', (t) => {
-  const { window, teardown } = setupJsdom();
+test('addTrade() from drawer pushes a HOLDING and persists to localStorage', async (t) => {
+  const { window, teardown } = await setupJsdom();
   t.after(teardown);
 
   // Asset defaults to BTC; fill the form fields addTrade reads.

--- a/test/integration/chain-sync-outcomes.test.js
+++ b/test/integration/chain-sync-outcomes.test.js
@@ -47,14 +47,14 @@ function ryskPosition({ isPut, strike, expiry, txHash, address, collateral, stat
 
 // ── resolveHsfcOutcomes ───────────────────────────────────────────────────────
 
-test('resolveHsfcOutcomes: PUT with redeemActions → ASSIGNED', (t) => {
+test('resolveHsfcOutcomes: PUT with redeemActions → ASSIGNED', async (t) => {
   const trade = {
     id: 1, asset: 'HYPE', type: 'PUT', platform: 'HSFC',
     date: '2026-04-01', expiry: PAST_EXPIRY_DATE,
     strike: 30.5, size: 50, premium: 10, outcome: 'EXPIRED',
     closeCost: 0, txHash: 'key-1',
   };
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   const changed = window.resolveHsfcOutcomes([
@@ -66,14 +66,14 @@ test('resolveHsfcOutcomes: PUT with redeemActions → ASSIGNED', (t) => {
   assert.strictEqual(storedOutcome(window, 1), 'ASSIGNED');
 });
 
-test('resolveHsfcOutcomes: CALL with redeemActions → CALLED', (t) => {
+test('resolveHsfcOutcomes: CALL with redeemActions → CALLED', async (t) => {
   const trade = {
     id: 2, asset: 'HYPE', type: 'CALL', platform: 'HSFC',
     date: '2026-04-01', expiry: PAST_EXPIRY_DATE,
     strike: 41.5, size: 50, premium: 8, outcome: 'EXPIRED',
     closeCost: 0, txHash: 'key-2',
   };
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   const changed = window.resolveHsfcOutcomes([
@@ -85,14 +85,14 @@ test('resolveHsfcOutcomes: CALL with redeemActions → CALLED', (t) => {
   assert.strictEqual(storedOutcome(window, 2), 'CALLED');
 });
 
-test('resolveHsfcOutcomes: empty redeemActions → stays EXPIRED', (t) => {
+test('resolveHsfcOutcomes: empty redeemActions → stays EXPIRED', async (t) => {
   const trade = {
     id: 3, asset: 'HYPE', type: 'PUT', platform: 'HSFC',
     date: '2026-04-01', expiry: PAST_EXPIRY_DATE,
     strike: 30.5, size: 50, premium: 10, outcome: 'EXPIRED',
     closeCost: 0, txHash: 'key-3',
   };
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   const changed = window.resolveHsfcOutcomes([
@@ -104,14 +104,14 @@ test('resolveHsfcOutcomes: empty redeemActions → stays EXPIRED', (t) => {
   assert.strictEqual(storedOutcome(window, 3), 'EXPIRED');
 });
 
-test('resolveHsfcOutcomes: CLOSED trade is not touched', (t) => {
+test('resolveHsfcOutcomes: CLOSED trade is not touched', async (t) => {
   const trade = {
     id: 4, asset: 'HYPE', type: 'PUT', platform: 'HSFC',
     date: '2026-04-01', expiry: PAST_EXPIRY_DATE,
     strike: 30.5, size: 50, premium: 10, outcome: 'CLOSED',
     closeCost: 5, txHash: 'key-4',
   };
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   const changed = window.resolveHsfcOutcomes([
@@ -123,14 +123,14 @@ test('resolveHsfcOutcomes: CLOSED trade is not touched', (t) => {
   assert.strictEqual(storedOutcome(window, 4), 'CLOSED');
 });
 
-test('resolveHsfcOutcomes: future expiry position is ignored', (t) => {
+test('resolveHsfcOutcomes: future expiry position is ignored', async (t) => {
   const trade = {
     id: 5, asset: 'HYPE', type: 'PUT', platform: 'HSFC',
     date: '2026-05-01', expiry: FUTURE_EXPIRY_DATE,
     strike: 30.5, size: 50, premium: 10, outcome: 'OPEN',
     closeCost: 0, txHash: 'key-5',
   };
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   const changed = window.resolveHsfcOutcomes([
@@ -142,14 +142,14 @@ test('resolveHsfcOutcomes: future expiry position is ignored', (t) => {
   assert.strictEqual(storedOutcome(window, 5), 'OPEN');
 });
 
-test('resolveHsfcOutcomes: unknown asset symbol is skipped', (t) => {
+test('resolveHsfcOutcomes: unknown asset symbol is skipped', async (t) => {
   const trade = {
     id: 6, asset: 'HYPE', type: 'PUT', platform: 'HSFC',
     date: '2026-04-01', expiry: PAST_EXPIRY_DATE,
     strike: 30.5, size: 50, premium: 10, outcome: 'EXPIRED',
     closeCost: 0, txHash: 'key-6',
   };
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   const changed = window.resolveHsfcOutcomes([
@@ -175,7 +175,7 @@ test('resolveRyskOutcomes: PUT settlementPrice <= strike → ASSIGNED', async (t
     closeCost: 0, txHash: '0xhash10',
   };
 
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   window.fetch = () => Promise.resolve({
@@ -204,7 +204,7 @@ test('resolveRyskOutcomes: PUT settlementPrice > strike → EXPIRED', async (t) 
     closeCost: 0, txHash: '0xhash11',
   };
 
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   window.fetch = () => Promise.resolve({
@@ -233,7 +233,7 @@ test('resolveRyskOutcomes: CALL settlementPrice >= strike → CALLED', async (t)
     closeCost: 0, txHash: '0xhash12',
   };
 
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   window.fetch = () => Promise.resolve({
@@ -262,7 +262,7 @@ test('resolveRyskOutcomes: CALL settlementPrice < strike → EXPIRED', async (t)
     closeCost: 0, txHash: '0xhash13',
   };
 
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   window.fetch = () => Promise.resolve({
@@ -291,7 +291,7 @@ test('resolveRyskOutcomes: CLOSED trade is not touched', async (t) => {
     closeCost: 3, txHash: '0xhash14',
   };
 
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   window.fetch = () => Promise.resolve({
@@ -318,7 +318,7 @@ test('resolveRyskOutcomes: non-SETTLED position is skipped', async (t) => {
     closeCost: 0, txHash: '0xhash15',
   };
 
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   let fetchCalled = false;
@@ -344,7 +344,7 @@ test('resolveRyskOutcomes: expiry-prices fetch failure → no crash, outcome unc
     closeCost: 0, txHash: '0xhash16',
   };
 
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   window.fetch = () => Promise.reject(new Error('Network error'));
@@ -370,7 +370,7 @@ test('resolveRyskOutcomes: PUT at exact strike boundary → ASSIGNED', async (t)
     closeCost: 0, txHash: '0xhash17',
   };
 
-  const { window, teardown } = setupJsdom({ trades: [trade] });
+  const { window, teardown } = await setupJsdom({ trades: [trade] });
   t.after(teardown);
 
   window.fetch = () => Promise.resolve({

--- a/test/integration/dte-term-split.test.js
+++ b/test/integration/dte-term-split.test.js
@@ -26,7 +26,7 @@ function clickHeader(window, theadId, label) {
   throw new Error('header not found: ' + label);
 }
 
-test('Open Positions DTE column shows live countdown, not stored t.dte', (t) => {
+test('Open Positions DTE column shows live countdown, not stored t.dte', async (t) => {
   // Stored dte=99 is the original term at open; expiry is 3d away — live should win.
   const openPut = {
     id: 1, asset: 'BTC', type: 'PUT',
@@ -34,7 +34,7 @@ test('Open Positions DTE column shows live countdown, not stored t.dte', (t) => 
     dte: 99, strike: 50000, size: 0.05, premium: 100,
     outcome: 'OPEN', closeCost: 0, platform: 'RYSK',
   };
-  const { window, teardown } = setupJsdom({ trades: [openPut] });
+  const { window, teardown } = await setupJsdom({ trades: [openPut] });
   t.after(teardown);
 
   const cells = window.document.querySelectorAll('#ttbody-open tr td');
@@ -44,14 +44,14 @@ test('Open Positions DTE column shows live countdown, not stored t.dte', (t) => 
   assert.ok(!/99/.test(dteCellText), 'should not render stored term 99 in live DTE column');
 });
 
-test('Position History column header reads "Term"; cell shows stored t.dte', (t) => {
+test('Position History column header reads "Term"; cell shows stored t.dte', async (t) => {
   const settled = {
     id: 2, asset: 'BTC', type: 'PUT',
     date: '2026-01-01', expiry: '2026-01-22',
     dte: 21, strike: 50000, size: 0.05, premium: 100,
     outcome: 'EXPIRED', closeCost: 0, platform: 'RYSK',
   };
-  const { window, teardown } = setupJsdom({ trades: [settled] });
+  const { window, teardown } = await setupJsdom({ trades: [settled] });
   t.after(teardown);
 
   const histHdr = window.document.getElementById('hist-hdr');
@@ -63,7 +63,7 @@ test('Position History column header reads "Term"; cell shows stored t.dte', (t)
   assert.strictEqual(cells[4].textContent.trim(), '21');
 });
 
-test('Open Positions DTE column sorts by expiry', (t) => {
+test('Open Positions DTE column sorts by expiry', async (t) => {
   // Two opens: stored dte order (5, 10) is opposite to expiry order.
   // After clicking DTE, ascending order should be by expiry (soonest first).
   // All three trades share the same stored dte (20). Old behavior would tie on
@@ -77,7 +77,7 @@ test('Open Positions DTE column sorts by expiry', (t) => {
     { id: 3, asset: 'HYPE', type: 'PUT', date: '2026-01-01', expiry: isoDaysFromToday(20),
       dte: 20, strike: 20, size: 50, premium: 30, outcome: 'OPEN', closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   clickHeader(window, 'open-hdr', 'DTE');

--- a/test/integration/expiry-table.test.js
+++ b/test/integration/expiry-table.test.js
@@ -12,7 +12,7 @@ function isoDaysFromToday(days) {
   return yyyy + '-' + mm + '-' + dd;
 }
 
-test('Expiring This Week APR matches Open Positions APR for the same trade', (t) => {
+test('Expiring This Week APR matches Open Positions APR for the same trade', async (t) => {
   // dte=21, premium=150, strike=50000, size=0.05
   // annual = (150 / (50000 * 0.05)) * (365 / 21) * 100 ≈ 104.8%
   const openPut = {
@@ -21,7 +21,7 @@ test('Expiring This Week APR matches Open Positions APR for the same trade', (t)
     dte: 21, strike: 50000, size: 0.05, premium: 150,
     outcome: 'OPEN', closeCost: 0, platform: 'RYSK',
   };
-  const { window, teardown } = setupJsdom({ trades: [openPut] });
+  const { window, teardown } = await setupJsdom({ trades: [openPut] });
   t.after(teardown);
 
   // Get APR from Open Positions table (column index 9 = APR: Asset,Platform,Date,Expiry,DTE,Type,Strike,Size,Premium,APR)
@@ -36,7 +36,7 @@ test('Expiring This Week APR matches Open Positions APR for the same trade', (t)
   assert.strictEqual(expiryApr, openApr, 'Expiring This Week APR must match Open Positions APR');
 });
 
-test('Expiring This Week respects asset filter', (t) => {
+test('Expiring This Week respects asset filter', async (t) => {
   const btcPut = {
     id: 1, asset: 'BTC', type: 'PUT',
     date: '2026-01-01', expiry: isoDaysFromToday(3),
@@ -49,7 +49,7 @@ test('Expiring This Week respects asset filter', (t) => {
     dte: 21, strike: 3000, size: 0.5, premium: 50,
     outcome: 'OPEN', closeCost: 0, platform: 'RYSK',
   };
-  const { window, teardown } = setupJsdom({ trades: [btcPut, ethPut] });
+  const { window, teardown } = await setupJsdom({ trades: [btcPut, ethPut] });
   t.after(teardown);
 
   // Apply ETH filter

--- a/test/integration/hero-total-tile.test.js
+++ b/test/integration/hero-total-tile.test.js
@@ -18,8 +18,8 @@ const HOLDING_BTC = {
   closeCost: 0, platform: 'SPOT',
 };
 
-test('hero band contains a Total P&L tile in the header row', (t) => {
-  const { window, teardown } = setupJsdom({ trades: [HOLDING_ETH] });
+test('hero band contains a Total P&L tile in the header row', async (t) => {
+  const { window, teardown } = await setupJsdom({ trades: [HOLDING_ETH] });
   t.after(teardown);
 
   const tile = window.document.getElementById('cpnl-tile');
@@ -29,9 +29,9 @@ test('hero band contains a Total P&L tile in the header row', (t) => {
   assert.ok(hero.contains(tile), 'tile must live inside the hero band');
 });
 
-test('hero tile Total = Realised + Unrealised', (t) => {
+test('hero tile Total = Realised + Unrealised', async (t) => {
   // PUT EXPIRED netPrem 100 + HOLDING ETH 3000 size 1 spot 3500 → total = 600.
-  const { window, teardown } = setupJsdom({ trades: [PUT_ETH_EXPIRED, HOLDING_ETH] });
+  const { window, teardown } = await setupJsdom({ trades: [PUT_ETH_EXPIRED, HOLDING_ETH] });
   t.after(teardown);
 
   window.livePrices = { ETH: 3500 };
@@ -44,8 +44,8 @@ test('hero tile Total = Realised + Unrealised', (t) => {
   assert.match(unrealised, /\+\$500/, `expected +$500 Unrealised, got "${unrealised}"`);
 });
 
-test('hero tile respects asset filter', (t) => {
-  const { window, teardown } = setupJsdom({ trades: [HOLDING_BTC, HOLDING_ETH] });
+test('hero tile respects asset filter', async (t) => {
+  const { window, teardown } = await setupJsdom({ trades: [HOLDING_BTC, HOLDING_ETH] });
   t.after(teardown);
 
   window.livePrices = { BTC: 52000, ETH: 3500 };
@@ -58,8 +58,8 @@ test('hero tile respects asset filter', (t) => {
   assert.match(total, /\+\$200/, `BTC-only Total should be +$200, got "${total}"`);
 });
 
-test('hero tile partial missing-spot: renders partial Total + sub-line, no asterisk', (t) => {
-  const { window, teardown } = setupJsdom({ trades: [HOLDING_ETH, HOLDING_BTC] });
+test('hero tile partial missing-spot: renders partial Total + sub-line, no asterisk', async (t) => {
+  const { window, teardown } = await setupJsdom({ trades: [HOLDING_ETH, HOLDING_BTC] });
   t.after(teardown);
 
   window.livePrices = { ETH: 3500 }; // BTC missing
@@ -75,8 +75,8 @@ test('hero tile partial missing-spot: renders partial Total + sub-line, no aster
     `tile must not contain an asterisk under partial state, got "${tile.textContent}"`);
 });
 
-test('hero tile full missing-spot: dashes + sub-line; Realised stays visible', (t) => {
-  const { window, teardown } = setupJsdom({ trades: [HOLDING_ETH, PUT_ETH_EXPIRED] });
+test('hero tile full missing-spot: dashes + sub-line; Realised stays visible', async (t) => {
+  const { window, teardown } = await setupJsdom({ trades: [HOLDING_ETH, PUT_ETH_EXPIRED] });
   t.after(teardown);
 
   // livePrices stays {} → ETH spot missing for the only open lot.

--- a/test/integration/holding-card-trim.test.js
+++ b/test/integration/holding-card-trim.test.js
@@ -22,24 +22,24 @@ const baseTrades = [
     closeCost: 0, platform: 'RYSK' },
 ];
 
-test('holding card has no hero sub-line', (t) => {
-  const { window, teardown } = setupJsdom({ trades: baseTrades });
+test('holding card has no hero sub-line', async (t) => {
+  const { window, teardown } = await setupJsdom({ trades: baseTrades });
   t.after(teardown);
   const card = getHcard(window);
   assert.strictEqual(card.querySelector('.hcard-hero-sub'), null,
     '.hcard-hero-sub should be removed');
 });
 
-test('holding card has no premium-reduction bar', (t) => {
-  const { window, teardown } = setupJsdom({ trades: baseTrades });
+test('holding card has no premium-reduction bar', async (t) => {
+  const { window, teardown } = await setupJsdom({ trades: baseTrades });
   t.after(teardown);
   const card = getHcard(window);
   assert.strictEqual(card.querySelector('.hcard-bar-wrap'), null,
     '.hcard-bar-wrap should be removed');
 });
 
-test('holding card footer has 3 stats: Cost Basis | CC Premiums | Premium Reduction %', (t) => {
-  const { window, teardown } = setupJsdom({ trades: baseTrades });
+test('holding card footer has 3 stats: Cost Basis | CC Premiums | Premium Reduction %', async (t) => {
+  const { window, teardown } = await setupJsdom({ trades: baseTrades });
   t.after(teardown);
   const card = getHcard(window);
 
@@ -59,8 +59,8 @@ test('holding card footer has 3 stats: Cost Basis | CC Premiums | Premium Reduct
   assert.match(values[2], /^2\.0%$/, `Reduction % value, got "${values[2]}"`);
 });
 
-test('Cost Basis appears exactly once on the card', (t) => {
-  const { window, teardown } = setupJsdom({ trades: baseTrades });
+test('Cost Basis appears exactly once on the card', async (t) => {
+  const { window, teardown } = await setupJsdom({ trades: baseTrades });
   t.after(teardown);
   const card = getHcard(window);
   const labels = Array.from(card.querySelectorAll('.hcard-stat-lbl'))

--- a/test/integration/holding-card-wide.test.js
+++ b/test/integration/holding-card-wide.test.js
@@ -25,16 +25,16 @@ function getGrid(window) {
   return g;
 }
 
-test('1 visible open lot: holdings-grid has --wide class', (t) => {
-  const { window, teardown } = setupJsdom({ trades: [ethHolding] });
+test('1 visible open lot: holdings-grid has --wide class', async (t) => {
+  const { window, teardown } = await setupJsdom({ trades: [ethHolding] });
   t.after(teardown);
   const grid = getGrid(window);
   assert.ok(grid.classList.contains('holdings-grid--wide'),
     'grid should have holdings-grid--wide class with 1 visible lot');
 });
 
-test('2 visible open lots: holdings-grid has --wide class', (t) => {
-  const { window, teardown } = setupJsdom({
+test('2 visible open lots: holdings-grid has --wide class', async (t) => {
+  const { window, teardown } = await setupJsdom({
     trades: [ethHolding, btcHolding(2, 2)],
   });
   t.after(teardown);
@@ -43,8 +43,8 @@ test('2 visible open lots: holdings-grid has --wide class', (t) => {
     'grid should have holdings-grid--wide class with 2 visible lots');
 });
 
-test('3 visible open lots: holdings-grid does NOT have --wide class', (t) => {
-  const { window, teardown } = setupJsdom({
+test('3 visible open lots: holdings-grid does NOT have --wide class', async (t) => {
+  const { window, teardown } = await setupJsdom({
     trades: [ethHolding, btcHolding(2, 2), btcHolding(3, 3)],
   });
   t.after(teardown);
@@ -53,8 +53,8 @@ test('3 visible open lots: holdings-grid does NOT have --wide class', (t) => {
     'grid should NOT have holdings-grid--wide class with 3+ visible lots');
 });
 
-test('asset filter honored: BTC filter w/ 1 BTC lot among many → wide', (t) => {
-  const { window, teardown } = setupJsdom({
+test('asset filter honored: BTC filter w/ 1 BTC lot among many → wide', async (t) => {
+  const { window, teardown } = await setupJsdom({
     trades: [ethHolding, btcHolding(2, 2), btcHolding(3, 3),
              { ...ethHolding, id: 4, date: '2026-02-01' }],
   });
@@ -66,9 +66,9 @@ test('asset filter honored: BTC filter w/ 1 BTC lot among many → wide', (t) =>
     'asset filter should narrow visible-lot count for the threshold');
 });
 
-test('missing spot: card renders stable Spot — placeholder', (t) => {
+test('missing spot: card renders stable Spot — placeholder', async (t) => {
   // No livePrices stub → spot is undefined.
-  const { window, teardown } = setupJsdom({ trades: [ethHolding] });
+  const { window, teardown } = await setupJsdom({ trades: [ethHolding] });
   t.after(teardown);
   const card = window.document.querySelector('.hcard');
   const spot = card.querySelector('.hcard-spot');
@@ -79,9 +79,9 @@ test('missing spot: card renders stable Spot — placeholder', (t) => {
     'placeholder sub-line should read "spot unavailable"');
 });
 
-test('wide layout preserves edit btn, lot badge, merge btn', (t) => {
+test('wide layout preserves edit btn, lot badge, merge btn', async (t) => {
   // 2 ETH lots: edit btn (HOLDING), lot badge (>1 lot), merge btn (>=2 open).
-  const { window, teardown } = setupJsdom({
+  const { window, teardown } = await setupJsdom({
     trades: [
       ethHolding,
       { ...ethHolding, id: 2, date: '2026-02-01', strike: 3200 },

--- a/test/integration/outcome-chart-filter.test.js
+++ b/test/integration/outcome-chart-filter.test.js
@@ -25,9 +25,9 @@ function makeSettledSet(n, outcome = 'EXPIRED', asset = 'BTC') {
   return out;
 }
 
-test('chart hidden + pills shown when < 10 settled trades', (t) => {
+test('chart hidden + pills shown when < 10 settled trades', async (t) => {
   const trades = makeSettledSet(5, 'EXPIRED');
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   const chart = window.document.getElementById('hist-outchart');
@@ -37,12 +37,12 @@ test('chart hidden + pills shown when < 10 settled trades', (t) => {
   assert.strictEqual(chart.querySelectorAll('.outchart-cell').length, 0);
 });
 
-test('chart shown + pills hidden when >= 10 settled trades', (t) => {
+test('chart shown + pills hidden when >= 10 settled trades', async (t) => {
   const trades = [
     ...makeSettledSet(7, 'EXPIRED'),
     ...makeSettledSet(3, 'CALLED'),
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   const chart = window.document.getElementById('hist-outchart');
@@ -53,12 +53,12 @@ test('chart shown + pills hidden when >= 10 settled trades', (t) => {
   assert.strictEqual(cells.length, 2, 'two outcomes → two cells');
 });
 
-test('clicking a cell filters the history table to that outcome', (t) => {
+test('clicking a cell filters the history table to that outcome', async (t) => {
   const trades = [
     ...makeSettledSet(7, 'EXPIRED'),
     ...makeSettledSet(3, 'CALLED'),
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   const cells = window.document.querySelectorAll('#hist-outchart .outchart-cell');
@@ -70,12 +70,12 @@ test('clicking a cell filters the history table to that outcome', (t) => {
   assert.strictEqual(histRows.length, 7);
 });
 
-test('clicking the active cell clears the filter (idempotent toggle)', (t) => {
+test('clicking the active cell clears the filter (idempotent toggle)', async (t) => {
   const trades = [
     ...makeSettledSet(7, 'EXPIRED'),
     ...makeSettledSet(3, 'CALLED'),
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   const getExpired = () => [...window.document.querySelectorAll('#hist-outchart .outchart-cell')]
@@ -90,12 +90,12 @@ test('clicking the active cell clears the filter (idempotent toggle)', (t) => {
   assert.strictEqual(histRows.length, 10, 'all 10 settled rows back in history');
 });
 
-test('asset filter chip changes the chart data', (t) => {
+test('asset filter chip changes the chart data', async (t) => {
   const trades = [
     ...makeSettledSet(7, 'EXPIRED', 'BTC'),
     ...makeSettledSet(5, 'ASSIGNED', 'ETH'),
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   let cells = window.document.querySelectorAll('#hist-outchart .outchart-cell');

--- a/test/integration/persistence-seam.test.js
+++ b/test/integration/persistence-seam.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { setupJsdom } = require('../helpers/setupJsdom');
+
+test('loadTrades() reads persisted trades from the seam on boot', async (t) => {
+  const seed = [{ id: 1, asset: 'BTC', type: 'HOLDING', strike: 50000, size: 0.1, outcome: 'OPEN', platform: 'SPOT' }];
+  const { window, teardown } = await setupJsdom({ trades: seed });
+  t.after(teardown);
+
+  const loaded = await window.loadTrades();
+  assert.strictEqual(loaded.length, 1);
+  assert.strictEqual(loaded[0].id, 1);
+});
+
+test('persist() writes hw_holdings and can be round-tripped by loadTrades()', async (t) => {
+  const { window, teardown } = await setupJsdom();
+  t.after(teardown);
+
+  const next = [{ id: 2, asset: 'ETH', type: 'HOLDING', strike: 3000, size: 1, outcome: 'OPEN', platform: 'SPOT' }];
+  await window.persist(next);
+
+  assert.strictEqual(window.localStorage.getItem('hw_holdings'), JSON.stringify(next));
+  assert.strictEqual(JSON.stringify(await window.loadTrades()), JSON.stringify(next));
+});
+
+test('currentUserKey() returns the wallet-derived key', async (t) => {
+  const wallet = '0x' + 'a'.repeat(40);
+  const { window, teardown } = await setupJsdom({ wallet });
+  t.after(teardown);
+
+  assert.strictEqual(window.currentUserKey(), wallet);
+});

--- a/test/integration/pnl-tiles.test.js
+++ b/test/integration/pnl-tiles.test.js
@@ -25,13 +25,13 @@ function assertHasTooltip(card, tipPattern) {
   if (!ico) throw new Error('expected ⓘ glyph (.ppnl-tip-ico) inside .ppnl-lbl');
 }
 
-test('Total Premium Collected tile has tooltip + ⓘ glyph', (t) => {
+test('Total Premium Collected tile has tooltip + ⓘ glyph', async (t) => {
   const trades = [
     { id: 1, asset: 'BTC', type: 'PUT', date: '2026-01-01', expiry: '2026-01-15',
       dte: 14, strike: 50000, size: 0.1, premium: 120, outcome: 'EXPIRED',
       closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   const card = findCard(window, /Total Premium Collected/i);
@@ -39,47 +39,47 @@ test('Total Premium Collected tile has tooltip + ⓘ glyph', (t) => {
   assertHasTooltip(card, /premium/i);
 });
 
-test('Total Notional tile has tooltip + ⓘ glyph', (t) => {
+test('Total Notional tile has tooltip + ⓘ glyph', async (t) => {
   const trades = [
     { id: 1, asset: 'BTC', type: 'PUT', date: '2026-01-01', expiry: '2026-01-15',
       dte: 14, strike: 50000, size: 0.1, premium: 120, outcome: 'EXPIRED',
       closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
   assertHasTooltip(findCard(window, /Total Notional/i), /notional|strike.*size/i);
 });
 
-test('Portfolio APR tile has tooltip + ⓘ glyph', (t) => {
+test('Portfolio APR tile has tooltip + ⓘ glyph', async (t) => {
   const trades = [
     { id: 1, asset: 'BTC', type: 'PUT', date: '2026-01-01', expiry: '2026-01-15',
       dte: 14, strike: 50000, size: 0.1, premium: 120, outcome: 'EXPIRED',
       closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
   assertHasTooltip(findCard(window, /Portfolio APR/i), /APR|annualised|annualized/i);
 });
 
-test('Return Rate tile has tooltip + ⓘ glyph', (t) => {
+test('Return Rate tile has tooltip + ⓘ glyph', async (t) => {
   const trades = [
     { id: 1, asset: 'BTC', type: 'PUT', date: '2026-01-01', expiry: '2026-01-15',
       dte: 14, strike: 50000, size: 0.1, premium: 120, outcome: 'EXPIRED',
       closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
   assertHasTooltip(findCard(window, /Return Rate/i), /OTM|expired/i);
 });
 
-test('Total tab uses hero + supporting trio layout (issue #42)', (t) => {
+test('Total tab uses hero + supporting trio layout (issue #42)', async (t) => {
   // Total Premium Collected is the hero (focal point); the other three live in a trio container.
   const trades = [
     { id: 1, asset: 'BTC', type: 'PUT', date: '2026-01-01', expiry: '2026-01-15',
       dte: 14, strike: 50000, size: 0.1, premium: 120, outcome: 'EXPIRED',
       closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   const hero = window.document.querySelector('.ppnl-hero');
@@ -101,7 +101,7 @@ test('Total tab uses hero + supporting trio layout (issue #42)', (t) => {
   assert.ok(hero.querySelector('.ppnl-tip-ico'), 'hero should keep the ⓘ glyph');
 });
 
-test('Total tab no longer renders Realised/Unrealised/Total P&L cards (issue #40)', (t) => {
+test('Total tab no longer renders Realised/Unrealised/Total P&L cards (issue #40)', async (t) => {
   // Per #40, the hero band is the canonical Realised/Unrealised/Total surface.
   // The Total tab must not duplicate them.
   const trades = [
@@ -112,7 +112,7 @@ test('Total tab no longer renders Realised/Unrealised/Total P&L cards (issue #40
       dte: null, strike: 3000, size: 1, premium: 0, outcome: 'OPEN',
       closeCost: 0, platform: 'SPOT' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   window.livePrices = { ETH: 3500 };
@@ -132,7 +132,7 @@ test('Total tab no longer renders Realised/Unrealised/Total P&L cards (issue #40
   assert.ok(findCard(window, /Return Rate/i));
 });
 
-test('Hero band has no duplicate Realised sparkline (#npnl-* removed)', (t) => {
+test('Hero band has no duplicate Realised sparkline (#npnl-* removed)', async (t) => {
   const trades = [
     { id: 1, asset: 'ETH', type: 'HOLDING', date: '2026-01-01', expiry: '',
       dte: null, strike: 3000, size: 1, premium: 0, outcome: 'OPEN',
@@ -141,7 +141,7 @@ test('Hero band has no duplicate Realised sparkline (#npnl-* removed)', (t) => {
       dte: 14, strike: 3500, size: 1, premium: 50, outcome: 'CALLED',
       closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   assert.strictEqual(window.document.getElementById('npnl-val'), null,
@@ -154,7 +154,7 @@ test('Hero band has no duplicate Realised sparkline (#npnl-* removed)', (t) => {
     '.npnl-spark wrapper should be removed');
 });
 
-test('Cumulative-hero sparkline header shows Realised P&L (premium + capital gain)', (t) => {
+test('Cumulative-hero sparkline header shows Realised P&L (premium + capital gain)', async (t) => {
   // HOLDING + CALLED → realised = 50 + 500 = 550. Hero header (#cpnl-val) should
   // show +$550, proving capital gain feeds the cumulative series (not premium-only).
   const trades = [
@@ -165,7 +165,7 @@ test('Cumulative-hero sparkline header shows Realised P&L (premium + capital gai
       dte: 14, strike: 3500, size: 1, premium: 50, outcome: 'CALLED',
       closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   const heroVal = window.document.getElementById('cpnl-val');
@@ -173,13 +173,13 @@ test('Cumulative-hero sparkline header shows Realised P&L (premium + capital gai
   assert.match(heroVal.textContent, /\+\$550/, `expected +$550 in cumulative hero, got "${heroVal.textContent}"`);
 });
 
-test('Premium P&L section is renamed to "Premium Economics" (issue #40)', (t) => {
+test('Premium P&L section is renamed to "Premium Economics" (issue #40)', async (t) => {
   const trades = [
     { id: 1, asset: 'BTC', type: 'PUT', date: '2026-01-01', expiry: '2026-01-15',
       dte: 14, strike: 50000, size: 0.1, premium: 120, outcome: 'EXPIRED',
       closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   const titles = Array.from(window.document.querySelectorAll('.sec-ttl'))
@@ -190,13 +190,13 @@ test('Premium P&L section is renamed to "Premium Economics" (issue #40)', (t) =>
     `"Premium P&L" section title should be gone, got ${JSON.stringify(titles)}`);
 });
 
-test('Holdings card Net Cost hero has tooltip + ⓘ glyph (lens disambiguation)', (t) => {
+test('Holdings card Net Cost hero has tooltip + ⓘ glyph (lens disambiguation)', async (t) => {
   const trades = [
     { id: 1, asset: 'ETH', type: 'HOLDING', date: '2026-01-01', expiry: '',
       dte: null, strike: 3000, size: 1, premium: 0, outcome: 'OPEN',
       closeCost: 0, platform: 'SPOT' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   // The Net Cost hero block — find by its label.
@@ -219,13 +219,13 @@ test('Holdings card Net Cost hero has tooltip + ⓘ glyph (lens disambiguation)'
   assert.ok(ico, 'expected ⓘ glyph next to the Net Cost label');
 });
 
-test('Monthly tab header reads "Realised P&L" (renamed from Net P&L)', (t) => {
+test('Monthly tab header reads "Realised P&L" (renamed from Net P&L)', async (t) => {
   const trades = [
     { id: 1, asset: 'BTC', type: 'PUT', date: '2026-01-01', expiry: '2026-01-15',
       dte: 14, strike: 50000, size: 0.1, premium: 120, outcome: 'EXPIRED',
       closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   window.setPpnlTab('monthly');
@@ -238,7 +238,7 @@ test('Monthly tab header reads "Realised P&L" (renamed from Net P&L)', (t) => {
     `"Net P&L" header should be gone, got ${JSON.stringify(headers)}`);
 });
 
-test('Monthly tab Realised value comes from computePnl (HOLDING + CALLED → premium + cap gain)', (t) => {
+test('Monthly tab Realised value comes from computePnl (HOLDING + CALLED → premium + cap gain)', async (t) => {
   // HOLDING ETH at 3000 size 1 (Jan), then CALL at 3500 size 1 premium 50, called Feb.
   // Cash-flow Realised for Feb = 50 + (3500-3000)*1 = 550. Old netPnl formula would
   // include +call-away notional ($3500), giving a very different number.
@@ -250,7 +250,7 @@ test('Monthly tab Realised value comes from computePnl (HOLDING + CALLED → pre
       dte: 14, strike: 3500, size: 1, premium: 50, outcome: 'CALLED',
       closeCost: 0, platform: 'RYSK' },
   ];
-  const { window, teardown } = setupJsdom({ trades });
+  const { window, teardown } = await setupJsdom({ trades });
   t.after(teardown);
 
   window.setPpnlTab('monthly');

--- a/test/integration/quick-outcome.test.js
+++ b/test/integration/quick-outcome.test.js
@@ -2,14 +2,14 @@ const test = require('node:test');
 const assert = require('node:assert');
 const { setupJsdom } = require('../helpers/setupJsdom');
 
-test('quickOutcome() marks an open PUT as EXPIRED and persists', (t) => {
+test('quickOutcome() marks an open PUT as EXPIRED and persists', async (t) => {
   const openPut = {
     id: 42,
     asset: 'BTC', type: 'PUT', date: '2026-02-01', expiry: '2026-02-22',
     dte: 21, strike: 50000, size: 0.05, premium: 100,
     outcome: 'OPEN', closeCost: 0, platform: 'RYSK',
   };
-  const { window, teardown } = setupJsdom({ trades: [openPut] });
+  const { window, teardown } = await setupJsdom({ trades: [openPut] });
   t.after(teardown);
 
   window.quickOutcome(42, 'EXPIRED');


### PR DESCRIPTION
## Parent
#86 · Closes #88

## What changed
Pulls persistence out of `core/` into a swappable async seam so a second app can supply its own storage without touching core. HyperWheel keeps its current wallet-KV + localStorage behaviour, now routed through the seam.

**Seam contract** (async from day one, per #84):
- `loadTrades(): Promise<Trade[]>`
- `persist(trades): Promise<void>`
- `currentUserKey(): string`

- New `src/js/crypto/12a-persistence.js` — crypto implementation wrapping `hw_holdings` + debounced cloud push; `currentUserKey()` returns the wallet.
- `core/02-utils.js` `save()` now routes through `persist(trades)` — no direct `localStorage`/cloud calls remain in core for trades.
- `core/17-boot.js` is now an async init that does `trades = await loadTrades()` and exposes a `bootReady` promise.
- Test harness: `setupJsdom` is async and awaits `bootReady` (trades load on a microtask); propagated `await` + `async (t)` to the sync integration tests. Added `persistence-seam.test.js`.
- CLAUDE.md file map updated.

## Acceptance criteria
- [x] Core boot-load and `save()` go through `loadTrades`/`persist`; no direct trade `localStorage`/cloud calls in core.
- [x] Crypto seam preserves current behaviour (`hw_holdings`, debounced cloud push, cloud pull on boot).
- [x] `currentUserKey()` exists and returns the wallet-derived key.
- [x] `npm test` green (123/123), including cloud-sync/HOLDINGS integration tests.
- [x] No behavioural change to HyperWheel.

Note: the boot-time `hw_synced_v1` staleness migration still reads localStorage directly in core — left as-is since it's chain-sync (crypto) state, not *trades*, so outside this seam's contract.