### PR TITLE
Wheeler 3: derive tickers from trades[] + hash-based colours (prefactor)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,9 @@ globals, and 17-boot.js runs an IIFE last to bootstrap the app.
 
 | File | Lines | Key exports / purpose |
 |------|------:|-----------------------|
-| `01-state.js` | 18 | `HW_WALLET_KEY`, `HW_HOLDINGS_KEY`, `HW_SYNCED_KEY`, `trades[]`, `sAsset/sType/sFilter/sPlatform/sSizeUnit/sPpnlTab/sCpnlPeriod`, `sHistOutcome/sHistFrom/sHistTo`, `livePrices{}`, `MIN_SIZE`, `ASSET_COLORS`, `mergeAsset` |
+| `01-state.js` | 18 | `HW_WALLET_KEY`, `HW_HOLDINGS_KEY`, `HW_SYNCED_KEY`, `trades[]`, `sAsset/sType/sFilter/sPlatform/sSizeUnit/sPpnlTab/sCpnlPeriod`, `sHistOutcome/sHistFrom/sHistTo`, `livePrices{}`, `mergeAsset` |
 | `01a-outcomes.js` | 32 | `OUTCOMES` registry: per-outcome `{title, badgeClass, platforms}`. Single source of truth for outcome display data + picker membership. Lot-lifecycle effects live in the Lot Engine, not here |
+| `01b-asset-meta.js` | 24 | `assetColor(sym)` (brand override → stable symbol-hash HSL fallback) and `minSize(sym)` (contract minimum, `0` for unknown tickers). Backed by `ASSET_BRAND`/`ASSET_MIN_SIZE` registries populated by platform modules. Dual-exported. Lets arbitrary tickers work with no config |
 | `02-utils.js` | 33 | `today()`, `save()` (routes trades through the persistence seam `persist()`), `fmt()` (max 2dp), `sk()` (K-abbrev), `loadWallet()`, `saveWallet()`, `toast(msg, kind?)` (`'ok'`/`'err'`/`'info'`). Dual-exports `today/fmt/sk` for Node tests |
 | `03-form-controls.js` | 212 | `setAsset/setType/setPlatform/setSizeUnit/setOut/setFilter/setPpnlTab`, `refreshLotPicker`, `autoFillFromLot`, `autoDTE`, history filters: `setHistOutcome/setHistFrom/setHistTo/clearHistFilters` |
 | `04-trade-crud.js` | 39 | `addTrade()` (HOLDING-only — adds spot from drawer), `clearForm`, `deleteTrade`, `quickOutcome` (fires toasts) |
@@ -67,6 +68,7 @@ globals, and 17-boot.js runs an IIFE last to bootstrap the app.
 | `08-render.js` | 8 | `render()` — orchestrator: `compute → rStats → rTable → rOutcomeChart → rCharts` |
 | `09-drawer-modal.js` | 15 | `openTradeDrawer`, `closeTradeDrawer`, `focusForm` |
 | `10-reset-modal.js` | 4 | `showReset`, `closeReset`, `doReset` (wipes `trades`) |
+| `11a-asset-brand.js` | 6 | Registers crypto brand colours + Rysk contract minimums as overrides on the core `ASSET_BRAND`/`ASSET_MIN_SIZE` registries (BTC/ETH/HYPE/SOL). Runs at load after `01b-asset-meta.js` |
 | `11-wallet-popup.js` | 34 | `showWalletPopup`, `hideWalletPopup`, `submitWalletPopup` (first-visit wallet entry) |
 | `12a-persistence.js` | 23 | **Persistence seam** (crypto impl): `loadTrades(): Promise<Trade[]>`, `persist(trades): Promise<void>`, `currentUserKey(): string`. Core reads/writes trades ONLY through these (async from day one, per #84). Crypto wraps `hw_holdings` + debounced cloud push |
 | `12-cloud-sync.js` | 66 | `_setCloudStatus`, `cloudPush` (debounced via `scheduleCloudPush`), `cloudPull` — pushes/pulls **only HOLDING trades** to `/api/sync` keyed by wallet. Toasts on error and on pull-with-data |
@@ -226,8 +228,14 @@ There is **no AI-key entry, no scanner state, no preferences object**.
 
 Hypersurface has no minimum contract size.
 
+Colours + minimums are now looked up via helpers (`01b-asset-meta.js`), not
+fixed maps: `assetColor(sym)` / `minSize(sym)`. Crypto brand values are
+registered as overrides in `11a-asset-brand.js`; unknown tickers fall back to a
+stable symbol-hash colour and `minSize` `0`.
+
 ```js
-const MIN_SIZE = { BTC: 0.05, ETH: 0.5, HYPE: 50, SOL: 10 };
+// crypto/11a-asset-brand.js registers the overrides:
+Object.assign(ASSET_MIN_SIZE, { BTC: 0.05, ETH: 0.5, HYPE: 50, SOL: 10 });
 ```
 
 Rysk size increments are exact: HYPE 50, ETH 0.5, BTC 0.05 (for both calls and puts).

--- a/src/js/core/01-state.js
+++ b/src/js/core/01-state.js
@@ -6,8 +6,8 @@ let trades = [];
 let sAsset = 'BTC', sType = 'PUT', sOut = 'OPEN', sFilter = 'ALL', sPlatform = 'RYSK', sSizeUnit = 'contracts', sPpnlTab = 'total', sCpnlPeriod = 'ALL';
 var livePrices = {};
 
-const MIN_SIZE = { BTC: 0.05, ETH: 0.5, HYPE: 50, SOL: 10 };
-const ASSET_COLORS = { BTC: '#f7931a', ETH: '#627eea', HYPE: '#00e5a0', SOL: '#9945ff' };
+// Per-ticker colour + contract minimum live in 01b-asset-meta.js (assetColor /
+// minSize), with crypto brand overrides in crypto/11a-asset-brand.js.
 
 // Merge modal state
 let mergeAsset = null;

--- a/src/js/core/01b-asset-meta.js
+++ b/src/js/core/01b-asset-meta.js
@@ -1,0 +1,24 @@
+// ── ASSET META (presentation) ────────────────────────────────
+// Per-ticker colour + contract minimum, derived so arbitrary tickers work with
+// no registry or config. Platform modules register brand overrides (e.g.
+// crypto's BTC orange) into these tables; unknown tickers fall back to a stable
+// symbol-hash colour and no contract minimum (TradFi has no per-asset minimum).
+const ASSET_BRAND = {};     // sym -> hex; populated by platform modules
+const ASSET_MIN_SIZE = {};  // sym -> min contract size
+
+// Stable hash → HSL so a given ticker always renders the same colour.
+function assetColor(sym) {
+  if (ASSET_BRAND[sym]) return ASSET_BRAND[sym];
+  const s = String(sym);
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return `hsl(${h % 360}, 65%, 55%)`;
+}
+
+function minSize(sym) {
+  return ASSET_MIN_SIZE[sym] ?? 0;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { ASSET_BRAND, ASSET_MIN_SIZE, assetColor, minSize };
+}

--- a/src/js/core/03-form-controls.js
+++ b/src/js/core/03-form-controls.js
@@ -18,8 +18,8 @@ function setAsset(a) {
       btn.style.cssText = `${baseStyle} var(--bd2);color:var(--mu);background:transparent`;
     }
   });
-  document.getElementById('f-size').value = sPlatform === 'HSFC' ? '' : MIN_SIZE[a];
-  document.getElementById('f-size-hint').textContent = sPlatform === 'HSFC' ? '' : 'min ' + MIN_SIZE[a] + ' ' + a;
+  document.getElementById('f-size').value = sPlatform === 'HSFC' ? '' : minSize(a);
+  document.getElementById('f-size-hint').textContent = sPlatform === 'HSFC' ? '' : 'min ' + minSize(a) + ' ' + a;
   document.getElementById('f-strike').placeholder = assetVars[a]?.placeholder || '100';
   refreshLotPicker();
 }
@@ -65,7 +65,7 @@ function setType(t) {
     if (document.getElementById('f-prem').value === '0') {
       document.getElementById('f-prem').value = '';
     }
-    document.getElementById('f-size').value = MIN_SIZE[sAsset];
+    document.getElementById('f-size').value = minSize(sAsset);
   }
   refreshLotPicker();
   refreshSizeUnitToggle();
@@ -85,9 +85,9 @@ function setPlatform(p) {
   if (OUTCOMES[sOut] && !OUTCOMES[sOut].platforms.includes(p)) setOut('OPEN');
   // Update size hint and default
   const sizeHint = document.getElementById('f-size-hint');
-  if (sizeHint) sizeHint.textContent = p === 'HSFC' ? '' : 'min ' + MIN_SIZE[sAsset] + ' ' + sAsset;
+  if (sizeHint) sizeHint.textContent = p === 'HSFC' ? '' : 'min ' + minSize(sAsset) + ' ' + sAsset;
   const sizeEl = document.getElementById('f-size');
-  if (sizeEl && !sizeEl.value) sizeEl.value = p === 'HSFC' ? '' : MIN_SIZE[sAsset];
+  if (sizeEl && !sizeEl.value) sizeEl.value = p === 'HSFC' ? '' : minSize(sAsset);
   // Show/hide size unit toggle (only for HSFC puts)
   refreshSizeUnitToggle();
   // Reset to contracts when switching away from HSFC

--- a/src/js/core/04-trade-crud.js
+++ b/src/js/core/04-trade-crud.js
@@ -19,7 +19,7 @@ function addTrade() {
 
 function clearForm() {
   ['f-strike','f-dte','f-closecost'].forEach(id => { const el = document.getElementById(id); if (el) el.value = ''; });
-  document.getElementById('f-size').value = MIN_SIZE[sAsset];
+  document.getElementById('f-size').value = minSize(sAsset);
   document.getElementById('ferr').style.display = 'none';
 }
 

--- a/src/js/core/05-compute.js
+++ b/src/js/core/05-compute.js
@@ -9,7 +9,8 @@
 // presentation-shape only.
 
 function compute(assetFilter) {
-  const assets = ['BTC', 'ETH', 'HYPE', 'SOL'];
+  // Derive the roster from the data so arbitrary tickers work with no registry.
+  const assets = [...new Set(trades.map(t => t.asset))];
   const streams = {};
   const lots = {};
 

--- a/src/js/crypto/11a-asset-brand.js
+++ b/src/js/crypto/11a-asset-brand.js
@@ -1,0 +1,6 @@
+// ── CRYPTO ASSET BRANDING ─────────────────────────────────────
+// Register crypto brand colours + Rysk contract minimums as overrides on the
+// core asset-meta registries. assetColor()/minSize() consult these first,
+// falling back to hash colour / no minimum for arbitrary tickers.
+Object.assign(ASSET_BRAND, { BTC: '#f7931a', ETH: '#627eea', HYPE: '#00e5a0', SOL: '#9945ff' });
+Object.assign(ASSET_MIN_SIZE, { BTC: 0.05, ETH: 0.5, HYPE: 50, SOL: 10 });

--- a/test/integration/asset-brand.test.js
+++ b/test/integration/asset-brand.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { setupJsdom } = require('../helpers/setupJsdom');
+
+test('crypto assets retain their brand colours; unknown ticker gets a hash colour', async (t) => {
+  const { window, teardown } = await setupJsdom();
+  t.after(teardown);
+
+  assert.strictEqual(window.assetColor('BTC'), '#f7931a');
+  assert.strictEqual(window.assetColor('ETH'), '#627eea');
+  assert.strictEqual(window.assetColor('HYPE'), '#00e5a0');
+  assert.strictEqual(window.assetColor('SOL'), '#9945ff');
+
+  assert.match(window.assetColor('TSLA'), /^hsl\(\d+, 65%, 55%\)$/);
+  assert.strictEqual(window.minSize('BTC'), 0.05);
+  assert.strictEqual(window.minSize('TSLA'), 0);
+});

--- a/test/unit/asset-meta.test.js
+++ b/test/unit/asset-meta.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { ASSET_BRAND, ASSET_MIN_SIZE, assetColor, minSize } = require('../../src/js/core/01b-asset-meta.js');
+
+test('assetColor: unknown ticker gets a stable colour across calls', () => {
+  const a = assetColor('TSLA');
+  const b = assetColor('TSLA');
+  assert.strictEqual(a, b);
+  assert.match(a, /^hsl\(\d+, 65%, 55%\)$/);
+});
+
+test('assetColor: different tickers generally differ', () => {
+  assert.notStrictEqual(assetColor('TSLA'), assetColor('AAPL'));
+});
+
+test('assetColor: registered brand override wins over the hash fallback', () => {
+  ASSET_BRAND.BTC = '#f7931a';
+  assert.strictEqual(assetColor('BTC'), '#f7931a');
+  delete ASSET_BRAND.BTC;
+});
+
+test('minSize: registered ticker returns its minimum; unknown returns 0', () => {
+  ASSET_MIN_SIZE.BTC = 0.05;
+  assert.strictEqual(minSize('BTC'), 0.05);
+  assert.strictEqual(minSize('TSLA'), 0);
+  delete ASSET_MIN_SIZE.BTC;
+});

--- a/test/unit/compute.test.js
+++ b/test/unit/compute.test.js
@@ -24,3 +24,20 @@ test('compute derives netCost = costBasis - lotPremiums/size for each open lot',
   // Lot 2: costBasis 48000, lotPremiums 60 (assigned-PUT premium), size 0.05 → 48000 - 60/0.05 = 46800
   assert.strictEqual(lots.BTC[1].netCost, 46800);
 });
+
+test('compute derives the roster from trades[] — arbitrary tickers work', () => {
+  global.trades = [
+    { id: 1, asset: 'TSLA', type: 'HOLDING', date: '2026-01-01', strike: 200, size: 10, premium: 0,  outcome: 'OPEN',    closeCost: 0, dte: null, expiry: '' },
+    { id: 2, asset: 'TSLA', type: 'CALL',    date: '2026-01-15', strike: 240, size: 10, premium: 50, outcome: 'EXPIRED', closeCost: 0, dte: 14,   expiry: '2026-01-29' },
+    { id: 3, asset: 'AAPL', type: 'HOLDING', date: '2026-02-01', strike: 180, size: 5,  premium: 0,  outcome: 'OPEN',    closeCost: 0, dte: null, expiry: '' },
+  ];
+  const { compute } = require('../../src/js/core/05-compute.js');
+  const { streams, lots } = compute('ALL');
+
+  // Streams/lots exist only for the tickers present in trades — no fixed four.
+  assert.deepStrictEqual(Object.keys(lots).sort(), ['AAPL', 'TSLA']);
+  assert.deepStrictEqual(Object.keys(streams).sort(), ['AAPL', 'TSLA']);
+
+  // TSLA lot: costBasis 200, lotPremiums 50 (call), size 10 → 200 - 50/10 = 195
+  assert.strictEqual(lots.TSLA[0].netCost, 195);
+});


### PR DESCRIPTION
## Parent
#86 · Closes #89

## What changed
Make the asset roster fully derived from the data instead of hardcoded, so arbitrary TradFi tickers work with no registry or config. HyperWheel is unaffected — its trades still yield BTC/ETH/HYPE/SOL.

- `compute()` derives its asset list from `trades[]` (`[...new Set(trades.map(t => t.asset))]`) rather than the fixed four.
- New `core/01b-asset-meta.js`: `assetColor(sym)` (brand override → stable symbol-hash HSL fallback) and `minSize(sym)` (contract minimum, `0` for unknown tickers), backed by `ASSET_BRAND`/`ASSET_MIN_SIZE` registries.
- New `crypto/11a-asset-brand.js`: registers crypto brand colours + Rysk contract minimums as overrides.
- `03-form-controls.js` / `04-trade-crud.js` route through `minSize()`.
- Removed the `MIN_SIZE` / `ASSET_COLORS` maps from `01-state.js`.
- CLAUDE.md file map + asset-config section updated.

## Acceptance criteria
- [x] `compute()` produces streams/lots for whatever tickers appear in `trades[]` (unit test with a TSLA/AAPL fixture).
- [x] An unknown ticker gets a stable colour across renders (`assetColor` hash → HSL).
- [x] Crypto assets retain their existing brand colours (jsdom test asserts `assetColor('BTC') === '#f7931a'`, etc.).
- [x] `npm test` green (129/129), compute tests extended with an arbitrary-ticker fixture.
- [x] No behavioural change to HyperWheel.

Note: crypto render/form layers (holdings cards, asset pills, chain-sync CG ids) still reference the fixed four — that's HyperWheel's own roster and out of scope for this core-focused prefactor.