### PR TITLE
Wheeler 6: equity/ETF live price feed (Finnhub + Twelve Data)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,9 @@ build.py                  # assembler: emits BOTH artifacts (core/ + crypto|trad
                           # tags the built <body data-app="crypto|tradfi"> for render-time app checks
 api/sync.js               # Vercel serverless: KV-backed cloud sync of HOLDINGs
 api/chain-sync.js         # Vercel serverless: CORS proxy to Rysk + Hypersurface
+api/quote.js              # Vercel serverless: key-injecting proxy for Wheeler
+                          # equity/ETF quotes (Finnhub + Twelve Data); keys live
+                          # in env vars FINNHUB_KEY / TWELVEDATA_KEY, not in HTML
 src/
   html/head.html          # <head> with /* CSS_PLACEHOLDER */ marker + {{APP_TITLE}}
   html/body.html          # shared <body> shell with {{FRAG:*}} markers

--- a/api/quote.js
+++ b/api/quote.js
@@ -1,0 +1,54 @@
+/**
+ * Server-side proxy for Wheeler live equity/ETF quotes (#92).
+ * Keeps the provider API keys server-side (Vercel env vars FINNHUB_KEY /
+ * TWELVEDATA_KEY) instead of shipping them in the built HTML. Transparent
+ * passthrough — the client keeps the Finnhub-primary → Twelve-Data-fallback
+ * failover, this just injects the key and dodges CORS.
+ *
+ * GET /api/quote?provider=finnhub&symbol=IBIT
+ * GET /api/quote?provider=twelvedata&symbols=IBIT,MSTR
+ */
+module.exports = async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') return res.status(200).end();
+
+  const { provider } = req.query;
+
+  // ── FINNHUB (primary) — one symbol per call ─────────────────
+  if (provider === 'finnhub') {
+    const symbol = req.query.symbol || '';
+    if (!/^[A-Za-z.\-]{1,12}$/.test(symbol)) {
+      return res.status(400).json({ error: 'Invalid symbol' });
+    }
+    const key = process.env.FINNHUB_KEY;
+    if (!key) return res.status(500).json({ error: 'FINNHUB_KEY not configured' });
+    try {
+      const upstream = await fetch(`https://finnhub.io/api/v1/quote?symbol=${encodeURIComponent(symbol)}&token=${key}`);
+      const data = await upstream.json();
+      return res.status(upstream.status).json(data);
+    } catch (e) {
+      return res.status(502).json({ error: 'Finnhub upstream failed: ' + e.message });
+    }
+  }
+
+  // ── TWELVE DATA (fallback + market-open state) — batched ─────
+  if (provider === 'twelvedata') {
+    const symbols = req.query.symbols || '';
+    if (!/^[A-Za-z0-9.,\-]{1,120}$/.test(symbols)) {
+      return res.status(400).json({ error: 'Invalid symbols' });
+    }
+    const key = process.env.TWELVEDATA_KEY;
+    if (!key) return res.status(500).json({ error: 'TWELVEDATA_KEY not configured' });
+    try {
+      const upstream = await fetch(`https://api.twelvedata.com/quote?symbol=${encodeURIComponent(symbols)}&apikey=${key}`);
+      const data = await upstream.json();
+      return res.status(upstream.status).json(data);
+    } catch (e) {
+      return res.status(502).json({ error: 'Twelve Data upstream failed: ' + e.message });
+    }
+  }
+
+  return res.status(400).json({ error: 'provider must be finnhub or twelvedata' });
+};

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -468,6 +468,10 @@ td.td-act { width:1px; white-space:nowrap; padding-right:12px; }
 .footer-live { color: var(--green); }
 .footer-live::before { content: '● '; }
 .footer-sep { color: var(--bd2); }
+.footer-market { font-weight: 700; letter-spacing: .5px; }
+.footer-market:not(:empty)::before { content: '· '; color: var(--bd2); font-weight: 400; }
+.footer-market.open { color: var(--green); }
+.footer-market.closed { color: var(--mu2); }
 .footer-source { margin-left: auto; display: inline-flex; align-items: center; color: var(--mu); transition: color .15s; }
 .footer-source:hover { color: var(--green); }
 .footer-source svg { display: block; }

--- a/src/html/tradfi/footer.html
+++ b/src/html/tradfi/footer.html
@@ -1,6 +1,7 @@
   <span class="footer-live">LIVE</span>
   <span class="footer-sep footer-deco">·</span>
   <span class="footer-deco">LOCAL</span>
+  <span id="footer-market" class="footer-market"></span>
   <span class="footer-sep">·</span>
   <span><a href="https://github.com/heyitsStylez/hyperwheel/releases/tag/{{VERSION_CLEAN}}" target="_blank" rel="noopener">{{VERSION}}</a></span>
   <a class="footer-source" href="https://github.com/heyitsStylez/hyperwheel" target="_blank" rel="noopener" title="View source on GitHub" aria-label="View source on GitHub"><svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg></a>

--- a/src/js/core/06-render-table.js
+++ b/src/js/core/06-render-table.js
@@ -277,6 +277,9 @@ function renderExpiryTable(allRows) {
 }
 
 function fetchExpiryPrices() {
+  // Wheeler marks equities/ETFs to spot via its own provider stack (#92); the
+  // shared Refresh button + boot route through here for both apps.
+  if (_isTradfi()) return wheelerFetchPrices();
   fetch('https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,hyperliquid,solana&vs_currencies=usd')
     .then(r => r.json())
     .then(data => {

--- a/src/js/tradfi/17-boot.js
+++ b/src/js/tradfi/17-boot.js
@@ -15,4 +15,5 @@ var bootReady = (async function init() {
 
   setType(sType);
   render();
+  fetchExpiryPrices();  // live equity/ETF spot for holdings cards (#92)
 })();

--- a/src/js/tradfi/18-price-feed.js
+++ b/src/js/tradfi/18-price-feed.js
@@ -1,0 +1,100 @@
+// ── LIVE PRICE FEED (tradfi / Wheeler) ────────────────────
+// Equity/ETF spot for Wheeler holdings, mirroring HyperWheel's CoinGecko flow
+// (fetchExpiryPrices) but for stocks/ETFs (#92). Finnhub is the primary
+// real-time source; Twelve Data is the fallback and the sole source of the
+// market-open indicator. Both are browser-direct (CORS-clear) — no proxy.
+//
+// Keys are user-supplied — this is a personal, local tool. Fill them in below;
+// a wrong/blank key just makes that provider error out and fail over. Tests stub
+// fetch, so the values don't matter there.
+const WHEELER_FINNHUB_KEY = '';
+const WHEELER_TWELVEDATA_KEY = '';
+
+// Market-open state from Twelve Data's is_market_open: true | false | null(unknown).
+// var (not let) so it lands on window for tests, like livePrices.
+var sMarketOpen = null;
+
+// Distinct tickers we hold or trade — the set to mark to spot.
+function wheelerHeldTickers() {
+  const seen = new Set();
+  trades.forEach(t => { if (t.asset) seen.add(t.asset); });
+  return [...seen];
+}
+
+// Finnhub /quote — one call per ticker, `c` is the current price. Any ticker
+// failing rejects the batch so the caller fails over to Twelve Data wholesale.
+async function finnhubPrices(tickers) {
+  const out = {};
+  await Promise.all(tickers.map(async t => {
+    const r = await fetch('https://finnhub.io/api/v1/quote?symbol=' + encodeURIComponent(t) + '&token=' + WHEELER_FINNHUB_KEY);
+    if (!r.ok) throw new Error('finnhub ' + r.status);
+    const d = await r.json();
+    const p = d && d.c;
+    if (typeof p !== 'number' || !p) throw new Error('finnhub no price for ' + t);
+    out[t] = p;
+  }));
+  return out;
+}
+
+// Twelve Data /quote — one batched call. Returns { prices, isMarketOpen }.
+// Single symbol → flat object; multiple → object keyed by symbol.
+async function twelveDataQuote(tickers) {
+  const r = await fetch('https://api.twelvedata.com/quote?symbol=' + tickers.map(encodeURIComponent).join(',') + '&apikey=' + WHEELER_TWELVEDATA_KEY);
+  if (!r.ok) throw new Error('twelvedata ' + r.status);
+  const d = await r.json();
+  if (d && d.status === 'error') throw new Error(d.message || 'twelvedata error');
+  const rows = tickers.length === 1 ? { [tickers[0]]: d } : d;
+  const prices = {};
+  let isMarketOpen = null;
+  tickers.forEach(t => {
+    const row = rows && rows[t];
+    if (!row || row.status === 'error') return;
+    const p = parseFloat(row.close);
+    if (p) prices[t] = p;
+    if (typeof row.is_market_open === 'boolean') isMarketOpen = row.is_market_open;
+  });
+  if (!Object.keys(prices).length) throw new Error('twelvedata no prices');
+  return { prices, isMarketOpen };
+}
+
+// Fetch live spot for held tickers: Finnhub primary, Twelve Data fallback. The
+// market-open indicator always comes from Twelve Data. A total outage leaves
+// livePrices untouched (never blanks the holdings cards).
+async function wheelerFetchPrices() {
+  const tickers = wheelerHeldTickers();
+  if (!tickers.length) return;
+
+  let prices = null, marketOpen = sMarketOpen;
+  try {
+    prices = await finnhubPrices(tickers);
+    // Finnhub carries no market state — ask Twelve Data just for the indicator.
+    try { marketOpen = (await twelveDataQuote(tickers)).isMarketOpen; }
+    catch (e) { /* keep last-known market state */ }
+  } catch (ePrimary) {
+    try {
+      const td = await twelveDataQuote(tickers);
+      prices = td.prices;
+      marketOpen = td.isMarketOpen;
+    } catch (eFallback) {
+      return; // both providers down — do not blank existing prices
+    }
+  }
+
+  livePrices = { ...livePrices, ...prices };
+  sMarketOpen = marketOpen;
+  wheelerUpdateStatus();
+
+  const el = document.getElementById('expiry-last-refreshed');
+  if (el) { const n = new Date(); el.textContent = 'refreshed ' + String(n.getUTCHours()).padStart(2, '0') + ':' + String(n.getUTCMinutes()).padStart(2, '0') + ' UTC'; }
+
+  render();
+}
+
+// Paint the footer market-open indicator from sMarketOpen.
+function wheelerUpdateStatus() {
+  const el = document.getElementById('footer-market');
+  if (!el) return;
+  if (sMarketOpen === true)  { el.textContent = 'MARKET OPEN';   el.className = 'footer-market open'; }
+  else if (sMarketOpen === false) { el.textContent = 'MARKET CLOSED'; el.className = 'footer-market closed'; }
+  else { el.textContent = ''; el.className = 'footer-market'; }
+}

--- a/src/js/tradfi/18-price-feed.js
+++ b/src/js/tradfi/18-price-feed.js
@@ -2,13 +2,13 @@
 // Equity/ETF spot for Wheeler holdings, mirroring HyperWheel's CoinGecko flow
 // (fetchExpiryPrices) but for stocks/ETFs (#92). Finnhub is the primary
 // real-time source; Twelve Data is the fallback and the sole source of the
-// market-open indicator. Both are browser-direct (CORS-clear) — no proxy.
+// market-open indicator.
 //
-// Keys are user-supplied — this is a personal, local tool. Fill them in below;
-// a wrong/blank key just makes that provider error out and fail over. Tests stub
-// fetch, so the values don't matter there.
-const WHEELER_FINNHUB_KEY = '';
-const WHEELER_TWELVEDATA_KEY = '';
+// Requests route through the /api/quote serverless proxy so the provider API
+// keys stay server-side (Vercel env vars FINNHUB_KEY / TWELVEDATA_KEY) instead
+// of shipping in the built HTML. Over file:// / a static server the proxy is
+// unreachable, so both providers "fail" and the feed silently shows no spot —
+// run `vercel dev` for live prices locally.
 
 // Market-open state from Twelve Data's is_market_open: true | false | null(unknown).
 // var (not let) so it lands on window for tests, like livePrices.
@@ -26,7 +26,7 @@ function wheelerHeldTickers() {
 async function finnhubPrices(tickers) {
   const out = {};
   await Promise.all(tickers.map(async t => {
-    const r = await fetch('https://finnhub.io/api/v1/quote?symbol=' + encodeURIComponent(t) + '&token=' + WHEELER_FINNHUB_KEY);
+    const r = await fetch('/api/quote?provider=finnhub&symbol=' + encodeURIComponent(t));
     if (!r.ok) throw new Error('finnhub ' + r.status);
     const d = await r.json();
     const p = d && d.c;
@@ -39,7 +39,7 @@ async function finnhubPrices(tickers) {
 // Twelve Data /quote — one batched call. Returns { prices, isMarketOpen }.
 // Single symbol → flat object; multiple → object keyed by symbol.
 async function twelveDataQuote(tickers) {
-  const r = await fetch('https://api.twelvedata.com/quote?symbol=' + tickers.map(encodeURIComponent).join(',') + '&apikey=' + WHEELER_TWELVEDATA_KEY);
+  const r = await fetch('/api/quote?provider=twelvedata&symbols=' + tickers.map(encodeURIComponent).join(','));
   if (!r.ok) throw new Error('twelvedata ' + r.status);
   const d = await r.json();
   if (d && d.status === 'error') throw new Error(d.message || 'twelvedata error');

--- a/test/integration/wheeler-price-feed.test.js
+++ b/test/integration/wheeler-price-feed.test.js
@@ -31,8 +31,8 @@ test('Finnhub primary: marks held ticker to spot on the holdings card', async (t
   t.after(teardown);
 
   window.fetch = routedFetch([
-    ['finnhub.io', () => ok({ c: 66 })],
-    ['twelvedata.com', () => ok({ symbol: 'IBIT', close: '66', is_market_open: true })],
+    ['provider=finnhub', () => ok({ c: 66 })],
+    ['provider=twelvedata', () => ok({ symbol: 'IBIT', close: '66', is_market_open: true })],
   ]);
 
   await window.wheelerFetchPrices();
@@ -49,8 +49,8 @@ test('primary failure falls back to Twelve Data without blanking prices', async 
   t.after(teardown);
 
   window.fetch = routedFetch([
-    ['finnhub.io', () => fail(500)],
-    ['twelvedata.com', () => ok({ symbol: 'IBIT', close: '62.5', is_market_open: false })],
+    ['provider=finnhub', () => fail(500)],
+    ['provider=twelvedata', () => ok({ symbol: 'IBIT', close: '62.5', is_market_open: false })],
   ]);
 
   await window.wheelerFetchPrices();
@@ -65,8 +65,8 @@ test('market-open indicator reflects Twelve Data is_market_open', async (t) => {
 
   // Open
   window.fetch = routedFetch([
-    ['finnhub.io', () => fail(500)],
-    ['twelvedata.com', () => ok({ symbol: 'IBIT', close: '62', is_market_open: true })],
+    ['provider=finnhub', () => fail(500)],
+    ['provider=twelvedata', () => ok({ symbol: 'IBIT', close: '62', is_market_open: true })],
   ]);
   await window.wheelerFetchPrices();
   assert.strictEqual(window.sMarketOpen, true);
@@ -74,8 +74,8 @@ test('market-open indicator reflects Twelve Data is_market_open', async (t) => {
 
   // Closed
   window.fetch = routedFetch([
-    ['finnhub.io', () => fail(500)],
-    ['twelvedata.com', () => ok({ symbol: 'IBIT', close: '62', is_market_open: false })],
+    ['provider=finnhub', () => fail(500)],
+    ['provider=twelvedata', () => ok({ symbol: 'IBIT', close: '62', is_market_open: false })],
   ]);
   await window.wheelerFetchPrices();
   assert.strictEqual(window.sMarketOpen, false);
@@ -88,8 +88,8 @@ test('both providers down leaves existing prices intact', async (t) => {
 
   window.livePrices = { IBIT: 99 };
   window.fetch = routedFetch([
-    ['finnhub.io', () => fail(500)],
-    ['twelvedata.com', () => fail(500)],
+    ['provider=finnhub', () => fail(500)],
+    ['provider=twelvedata', () => fail(500)],
   ]);
 
   await window.wheelerFetchPrices();
@@ -106,8 +106,8 @@ test('multi-ticker Twelve Data fallback keyed by symbol', async (t) => {
   t.after(teardown);
 
   window.fetch = routedFetch([
-    ['finnhub.io', () => fail(500)],
-    ['twelvedata.com', () => ok({
+    ['provider=finnhub', () => fail(500)],
+    ['provider=twelvedata', () => ok({
       IBIT: { symbol: 'IBIT', close: '62', is_market_open: true },
       MSTR: { symbol: 'MSTR', close: '355', is_market_open: true },
     })],

--- a/test/integration/wheeler-price-feed.test.js
+++ b/test/integration/wheeler-price-feed.test.js
@@ -1,0 +1,120 @@
+// Wheeler (tradfi) live price-feed integration test (#92). Boots the second
+// artifact in jsdom and drives wheelerFetchPrices() with a URL-routed fetch stub
+// to assert: (1) held tickers are marked to spot on holdings cards, (2) a
+// Finnhub (primary) failure falls back to Twelve Data without blanking prices,
+// (3) the market-open indicator reflects Twelve Data's is_market_open, and
+// (4) both-providers-down leaves existing prices intact.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { setupJsdom } = require('../helpers/setupJsdom');
+
+// Build a fetch stub that routes by URL substring. Each route is
+// [substring, handler] where handler(url) -> Promise<{ok,status,json}>.
+function routedFetch(routes) {
+  return (url) => {
+    for (const [needle, handler] of routes) {
+      if (String(url).includes(needle)) return handler(url);
+    }
+    return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+  };
+}
+const ok = (body) => Promise.resolve({ ok: true, status: 200, json: async () => body });
+const fail = (status = 500) => Promise.resolve({ ok: false, status, json: async () => ({}) });
+
+const holding = (over = {}) => ({
+  id: 1, asset: 'IBIT', type: 'HOLDING', date: '2026-01-02', expiry: '', dte: null,
+  strike: 60, size: 100, premium: 0, outcome: 'OPEN', closeCost: 0, platform: 'MANUAL', ...over,
+});
+
+test('Finnhub primary: marks held ticker to spot on the holdings card', async (t) => {
+  const { window, teardown } = await setupJsdom({ app: 'tradfi', trades: [holding()] });
+  t.after(teardown);
+
+  window.fetch = routedFetch([
+    ['finnhub.io', () => ok({ c: 66 })],
+    ['twelvedata.com', () => ok({ symbol: 'IBIT', close: '66', is_market_open: true })],
+  ]);
+
+  await window.wheelerFetchPrices();
+
+  assert.strictEqual(window.livePrices.IBIT, 66, 'Finnhub price should populate livePrices');
+  // Net cost = 60, spot 66, 100 shares → +$600 unrealised on the holdings card.
+  const holdings = window.document.getElementById('ncbwrap').innerHTML;
+  assert.match(holdings, /\$66\b/, 'holdings card should show live spot');
+  assert.match(holdings, /\+\$600\b/, 'holdings card should mark unrealised P&L vs net cost');
+});
+
+test('primary failure falls back to Twelve Data without blanking prices', async (t) => {
+  const { window, teardown } = await setupJsdom({ app: 'tradfi', trades: [holding()] });
+  t.after(teardown);
+
+  window.fetch = routedFetch([
+    ['finnhub.io', () => fail(500)],
+    ['twelvedata.com', () => ok({ symbol: 'IBIT', close: '62.5', is_market_open: false })],
+  ]);
+
+  await window.wheelerFetchPrices();
+
+  assert.strictEqual(window.livePrices.IBIT, 62.5, 'fallback should populate price from Twelve Data');
+  assert.match(window.document.getElementById('ncbwrap').innerHTML, /\$62.5\b/);
+});
+
+test('market-open indicator reflects Twelve Data is_market_open', async (t) => {
+  const { window, teardown } = await setupJsdom({ app: 'tradfi', trades: [holding()] });
+  t.after(teardown);
+
+  // Open
+  window.fetch = routedFetch([
+    ['finnhub.io', () => fail(500)],
+    ['twelvedata.com', () => ok({ symbol: 'IBIT', close: '62', is_market_open: true })],
+  ]);
+  await window.wheelerFetchPrices();
+  assert.strictEqual(window.sMarketOpen, true);
+  assert.match(window.document.getElementById('footer-market').textContent, /OPEN/i);
+
+  // Closed
+  window.fetch = routedFetch([
+    ['finnhub.io', () => fail(500)],
+    ['twelvedata.com', () => ok({ symbol: 'IBIT', close: '62', is_market_open: false })],
+  ]);
+  await window.wheelerFetchPrices();
+  assert.strictEqual(window.sMarketOpen, false);
+  assert.match(window.document.getElementById('footer-market').textContent, /CLOSED/i);
+});
+
+test('both providers down leaves existing prices intact', async (t) => {
+  const { window, teardown } = await setupJsdom({ app: 'tradfi', trades: [holding()] });
+  t.after(teardown);
+
+  window.livePrices = { IBIT: 99 };
+  window.fetch = routedFetch([
+    ['finnhub.io', () => fail(500)],
+    ['twelvedata.com', () => fail(500)],
+  ]);
+
+  await window.wheelerFetchPrices();
+
+  assert.strictEqual(window.livePrices.IBIT, 99, 'a total provider outage must not blank prices');
+});
+
+test('multi-ticker Twelve Data fallback keyed by symbol', async (t) => {
+  const seed = [
+    holding({ id: 1, asset: 'IBIT', strike: 60, size: 100 }),
+    holding({ id: 2, asset: 'MSTR', strike: 300, size: 10 }),
+  ];
+  const { window, teardown } = await setupJsdom({ app: 'tradfi', trades: seed });
+  t.after(teardown);
+
+  window.fetch = routedFetch([
+    ['finnhub.io', () => fail(500)],
+    ['twelvedata.com', () => ok({
+      IBIT: { symbol: 'IBIT', close: '62', is_market_open: true },
+      MSTR: { symbol: 'MSTR', close: '355', is_market_open: true },
+    })],
+  ]);
+
+  await window.wheelerFetchPrices();
+
+  assert.strictEqual(window.livePrices.IBIT, 62);
+  assert.strictEqual(window.livePrices.MSTR, 355);
+});


### PR DESCRIPTION
Closes #92.

Gives Wheeler live spot for held tickers so holdings cards mark unrealised P&L against the market, mirroring HyperWheel's CoinGecko flow but for equities/ETFs.

## What's in it
- **`src/js/tradfi/18-price-feed.js`** — `wheelerFetchPrices()`: Finnhub primary (per-ticker `/quote`), Twelve Data batched fallback. Primary error → fallback; both down leaves `livePrices` untouched (never blanks cards). Feeds the existing holdings-card path (live spot, unrealised P&L vs net cost, "next call ≥ $X" hint).
- **Market-open indicator** — sourced from Twelve Data `is_market_open`, painted into a new `#footer-market` span (styled with `:root` vars).
- **Core dispatch** — `fetchExpiryPrices()` routes to `wheelerFetchPrices()` under `_isTradfi()`, so Wheeler's shared Refresh button + boot feed the new feed.
- **`api/quote.js`** — key-injecting serverless proxy (mirrors `api/chain-sync.js`). Provider keys live in Vercel env vars `FINNHUB_KEY` / `TWELVEDATA_KEY`, never in the built HTML. Client keeps its failover; only request URLs change to `/api/quote?provider=...`.

## Acceptance criteria
- [x] Fetches live spot for held tickers and marks unrealised P&L on holdings cards.
- [x] Primary-provider failure falls back to the secondary without blanking prices.
- [x] Market-open/closed indicator reflects `is_market_open`.
- [x] `npm test` green with `fetch` stubbed for both providers (failover + indicator asserted).

## Notes
- Over `file://` / a static server the proxy is unreachable, so the feed silently shows no spot — run `vercel dev` for local prices.
- Requires `FINNHUB_KEY` / `TWELVEDATA_KEY` set in the Vercel project env (done).

## Tests
5 new integration tests in `test/integration/wheeler-price-feed.test.js`; full suite 150/150 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)