### PR TITLE
Wheeler: holdings UI tweaks — shares display, P&L tooltips, drop next-call hint

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -261,8 +261,6 @@ tr.lot-child.la-sol:hover > td{background:rgba(153,69,255,.08)}
 .hcard-pnl.green{color:var(--green)}
 .hcard-pnl.red{color:var(--red)}
 .hcard-hint{margin-top:6px;font-size:.6rem;color:var(--mu2);font-family:var(--mono);line-height:1.45}
-.hcard-hint b{color:var(--orange);font-weight:700}
-.hcard-hint-ok{color:var(--green)}
 .lot-badge{font-size:.5rem;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;padding:2px 6px;background:var(--s3);border:1px solid var(--bd2);color:var(--mu2);font-family:var(--mono)}
 .hcard-spot-muted{color:var(--mu2)}
 

--- a/src/html/body.html
+++ b/src/html/body.html
@@ -28,11 +28,11 @@
       </div>
       <div class="cpnl-hero-tile" id="cpnl-tile">
         <div class="cpnl-tile-row">
-          <span class="cpnl-tile-lbl">Unrealised</span>
+          <span class="cpnl-tile-lbl has-tip" data-tip="Unrealised = Σ over open lots of (spot − cost basis) × size. Marks each open lot to the live spot price against its raw cost basis (not net cost). Lots with no spot price are excluded.">Unrealised <span class="tip-ico" aria-hidden="true">&#9432;</span></span>
           <span class="cpnl-tile-unrealised" id="cpnl-tile-unrealised">—</span>
         </div>
         <div class="cpnl-tile-row cpnl-tile-row-total">
-          <span class="cpnl-tile-lbl">Total</span>
+          <span class="cpnl-tile-lbl has-tip" data-tip="Total = Realised + Unrealised. Realised = settled net premiums + capital gains on called-away lots (strike − cost basis) × size. Unrealised marks open lots to spot.">Total <span class="tip-ico" aria-hidden="true">&#9432;</span></span>
           <span class="cpnl-tile-total" id="cpnl-tile-total">—</span>
         </div>
         <div class="cpnl-tile-sub" id="cpnl-tile-sub"></div>

--- a/src/js/core/06-render-table.js
+++ b/src/js/core/06-render-table.js
@@ -371,21 +371,12 @@ function rTable(displayRows, streams, lots) {
         const pnlPct = nc > 0 ? (pnlPerToken / nc * 100) : 0;
         const cls = pnlTotal >= 0 ? 'green' : 'red';
         const sign = pnlTotal >= 0 ? '+' : '';
-        let hint;
-        if (nc > spot) {
-          const need = ((nc - spot) / spot * 100).toFixed(1);
-          hint = '<div class="hcard-hint">Next call &ge; <b>$' + fmt(nc) + '</b> &mdash; ' + need + '% above spot to stay above net cost</div>';
-        } else {
-          const cushion = ((spot - nc) / spot * 100).toFixed(1);
-          hint = '<div class="hcard-hint hcard-hint-ok">Spot is ' + cushion + '% above net cost &mdash; any call &ge; spot is profitable</div>';
-        }
         spotBlock = '<div class="hcard-spot">'
           +   '<div class="hcard-spot-row">'
           +     '<span class="hcard-spot-lbl">Spot</span>'
           +     '<span class="hcard-spot-val">$' + fmt(spot) + '</span>'
           +     '<span class="hcard-pnl ' + cls + '">' + sign + '$' + fmt(pnlTotal) + ' (' + sign + pnlPct.toFixed(1) + '%)</span>'
           +   '</div>'
-          +   hint
           + '</div>';
       }
 
@@ -393,7 +384,7 @@ function rTable(displayRows, streams, lots) {
         + '<div class="hcard-hd">'
         +   '<div class="hcard-asset">'
         +     '<span class="' + tickClass + '"' + tickStyle + '>' + glyph + ' ' + a + '</span>'
-        +     '<span class="hcard-size">' + fmtSize(lot.size) + '</span>'
+        +     '<span class="hcard-size">' + (_isTradfi() ? fmt(lot.size) + ' sh' : fmtSize(lot.size)) + '</span>'
         +     lotBadge
         +   '</div>'
         +   '<div style="display:flex;align-items:center;gap:8px">'

--- a/test/integration/wheeler-app.test.js
+++ b/test/integration/wheeler-app.test.js
@@ -296,16 +296,17 @@ test('display toggle: size renders as contracts or shares across tables + cards'
   const openBody = () => doc.getElementById('ttbody-open').innerHTML;
   const holdings = () => doc.getElementById('ncbwrap').innerHTML;
 
-  // Default is contracts: 300 shares → "3 ct".
+  // Default is contracts for option rows: 300 shares → "3 ct". Holdings are
+  // physical shares, so the holdings card always shows shares regardless of toggle.
   assert.match(openBody(), /3 ct/, 'open table should show contracts by default');
   assert.doesNotMatch(openBody(), /300 sh/);
-  assert.match(holdings(), /3 ct/, 'holdings card should show contracts by default');
+  assert.match(holdings(), /300 sh/, 'holdings card should always show shares');
 
   // Toggle to shares.
   window.setSizeDisplay('shares');
   assert.match(openBody(), /300 sh/, 'open table should show shares after toggle');
   assert.doesNotMatch(openBody(), /3 ct/);
-  assert.match(holdings(), /300 sh/, 'holdings card should show shares after toggle');
+  assert.match(holdings(), /300 sh/, 'holdings card stays in shares after toggle');
 
   // Toggle button reflects active state.
   assert.match(doc.getElementById('sd-shares').className, /active/);


### PR DESCRIPTION
Holdings/P&L UI refinements requested after reviewing the deployed Wheeler `/wheeler`:

- **Holdings show physical shares** — holdings cards now always render size in shares (e.g. `100 sh`), never contracts. Holdings are stock, not option contracts, so the CONTRACTS/SHARES toggle no longer applies to them; it still governs the option rows.
- **P&L tooltips** — added ⓘ tooltips to the hero tile's **Unrealised** and **Total** labels explaining how each is calculated (mark-to-spot vs realised + unrealised).
- **Dropped the next-call hint** — removed the "Next call ≥ \$X — X% above spot to stay above net cost" line from holdings cards in **both** HyperWheel and Wheeler, plus the now-orphaned `.hcard-hint b` / `.hcard-hint-ok` CSS.

Build passes both artifacts; 150 tests green (updated the size-display integration test to expect shares on the holdings card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)