### PR TITLE
Fix Unrealised/Total P&L tooltip clipped at top of hero

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -307,6 +307,9 @@ tr.lot-child.la-sol:hover > td{background:rgba(153,69,255,.08)}
 .ppnl-card.has-tip:hover{border-color:var(--mu)}
 .has-tip::after{content:attr(data-tip);position:absolute;left:50%;bottom:calc(100% + 8px);transform:translateX(-50%);background:#0c1119;color:var(--text);border:1px solid var(--bd);border-radius:8px;padding:8px 10px;font-family:var(--mono);font-size:.7rem;line-height:1.45;width:max-content;max-width:300px;white-space:normal;text-align:left;box-shadow:0 8px 24px rgba(0,0,0,.45);opacity:0;pointer-events:none;transition:opacity .12s ease;z-index:20}
 .has-tip:hover::after{opacity:1}
+/* Flip the popover below the anchor — for tips near the top of a section or
+   inside an overflow:hidden container (e.g. the cpnl hero tiles). */
+.has-tip--below::after{bottom:auto;top:calc(100% + 8px)}
 .ppnl-lbl{font-size:.6rem;font-weight:700;text-transform:uppercase;letter-spacing:1.1px;color:var(--mu);font-family:var(--mono);margin-bottom:10px}
 .ppnl-main{font-size:1.05rem;font-weight:700;color:var(--text);font-family:var(--mono);line-height:1.1}
 .ppnl-sub{font-size:.65rem;color:var(--mu);font-family:var(--mono);margin-top:4px}

--- a/src/html/body.html
+++ b/src/html/body.html
@@ -28,11 +28,11 @@
       </div>
       <div class="cpnl-hero-tile" id="cpnl-tile">
         <div class="cpnl-tile-row">
-          <span class="cpnl-tile-lbl has-tip" data-tip="Unrealised = Σ over open lots of (spot − cost basis) × size. Marks each open lot to the live spot price against its raw cost basis (not net cost). Lots with no spot price are excluded.">Unrealised <span class="tip-ico" aria-hidden="true">&#9432;</span></span>
+          <span class="cpnl-tile-lbl has-tip has-tip--below" data-tip="Unrealised = Σ over open lots of (spot − cost basis) × size. Marks each open lot to the live spot price against its raw cost basis (not net cost). Lots with no spot price are excluded.">Unrealised <span class="tip-ico" aria-hidden="true">&#9432;</span></span>
           <span class="cpnl-tile-unrealised" id="cpnl-tile-unrealised">—</span>
         </div>
         <div class="cpnl-tile-row cpnl-tile-row-total">
-          <span class="cpnl-tile-lbl has-tip" data-tip="Total = Realised + Unrealised. Realised = settled net premiums + capital gains on called-away lots (strike − cost basis) × size. Unrealised marks open lots to spot.">Total <span class="tip-ico" aria-hidden="true">&#9432;</span></span>
+          <span class="cpnl-tile-lbl has-tip has-tip--below" data-tip="Total = Realised + Unrealised. Realised = settled net premiums + capital gains on called-away lots (strike − cost basis) × size. Unrealised marks open lots to spot.">Total <span class="tip-ico" aria-hidden="true">&#9432;</span></span>
           <span class="cpnl-tile-total" id="cpnl-tile-total">—</span>
         </div>
         <div class="cpnl-tile-sub" id="cpnl-tile-sub"></div>


### PR DESCRIPTION
The Unrealised/Total hero-tile tooltips rendered above their label, so near the top of the P&L section — and inside `.cpnl-hero`'s `overflow:hidden` — they were mostly cut off.

Add a `.has-tip--below` variant that flips the popover beneath the anchor, and apply it to the Unrealised and Total tile labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)