### PR TITLE
Wheeler: dynamic per-ticker filter tabs

### DIFF
--- a/src/js/core/03-form-controls.js
+++ b/src/js/core/03-form-controls.js
@@ -177,7 +177,7 @@ function autoFillFromLot() {
 }
 function setFilter(f) {
   sFilter = f;
-  ['ALL','BTC','ETH','HYPE','SOL'].forEach(x => { const el = document.getElementById('fb-'+x); if(el) el.classList.toggle('active', x===f); });
+  document.querySelectorAll('.asset-tabs [id^="fb-"]').forEach(el => el.classList.toggle('active', el.id === 'fb-'+f));
   render();
 }
 

--- a/src/js/core/06-render-table.js
+++ b/src/js/core/06-render-table.js
@@ -53,6 +53,26 @@ function _platCol(cell) {
   return _isTradfi() ? '' : cell;
 }
 
+// Wheeler tickers are arbitrary and discovered from trades[], so its filter bar
+// is data-derived: one tab per traded ticker with a stable assetColor() dot.
+// Crypto keeps its static fixed-roster fragment untouched.
+function rFilterTabs() {
+  if (!_isTradfi()) return;
+  const bar = document.querySelector('.asset-tabs');
+  if (!bar) return;
+  const tickers = [...new Set(trades.map(t => t.asset).filter(Boolean))].sort();
+  let html = '<button class="asset-tab all' + (sFilter === 'ALL' ? ' active' : '')
+    + '" id="fb-ALL" onclick="setFilter(\'ALL\')">All Tickers</button>';
+  tickers.forEach(t => {
+    const on = sFilter === t;
+    const style = on ? ' style="border-color:' + assetColor(t) + ';color:' + assetColor(t) + '"' : '';
+    html += '<button class="asset-tab' + (on ? ' active' : '') + '" id="fb-' + t + '" onclick="setFilter(\''
+      + t + '\')"' + style + '><span class="asset-dot" style="background:' + assetColor(t) + '"></span> '
+      + t + '</button>';
+  });
+  bar.innerHTML = html;
+}
+
 // Display boundary for `size` (always stored in shares). Wheeler shows either
 // contracts (shares ÷ 100) or shares per the sSizeDisplay toggle; crypto is
 // unaffected — pass `asset` to append the token symbol as before.

--- a/src/js/core/08-render.js
+++ b/src/js/core/08-render.js
@@ -1,6 +1,10 @@
 // ── RENDER
 function render() {
+  // Wheeler tabs are data-derived, so a filtered ticker can vanish when its last
+  // trade is deleted — fall back to ALL rather than showing an empty, tab-less view.
+  if (_isTradfi() && sFilter !== 'ALL' && !trades.some(t => t.asset === sFilter)) sFilter = 'ALL';
   const { streams, lots, allRows, displayRows } = compute(sFilter);
+  rFilterTabs();
   rStats(streams, lots, allRows, displayRows);
   rTable(displayRows, streams, lots);
   rOutcomeChart();

--- a/test/integration/wheeler-app.test.js
+++ b/test/integration/wheeler-app.test.js
@@ -324,3 +324,36 @@ test('seeded wheeler_trades load on boot and survive a reload', async (t) => {
   const { lots } = window.compute();
   assert.ok((lots.IBIT || []).some(l => l.open), 'seeded IBIT holding should load into a lot');
 });
+
+test('filter tabs are derived from traded tickers and scope the view', async (t) => {
+  const seed = [
+    { id: 1, asset: 'IBIT', type: 'HOLDING', date: '2026-01-02', expiry: '', dte: null,
+      strike: 60, size: 100, premium: 0, outcome: 'OPEN', closeCost: 0, platform: 'MANUAL' },
+    { id: 2, asset: 'PURR', type: 'HOLDING', date: '2026-01-03', expiry: '', dte: null,
+      strike: 12, size: 200, premium: 0, outcome: 'OPEN', closeCost: 0, platform: 'MANUAL' },
+  ];
+  const { window, teardown } = await setupJsdom({ app: 'tradfi', trades: seed });
+  t.after(teardown);
+  const doc = window.document;
+
+  // One tab per traded ticker plus the All Tickers tab — no fixed crypto roster.
+  const bar = doc.querySelector('.asset-tabs');
+  assert.ok(doc.getElementById('fb-IBIT'), 'IBIT tab rendered from trades');
+  assert.ok(doc.getElementById('fb-PURR'), 'PURR tab rendered from trades');
+  assert.strictEqual(doc.getElementById('fb-BTC'), null, 'no fixed crypto tabs on Wheeler');
+  assert.match(bar.innerHTML, /All Tickers/);
+
+  // setFilter scopes to a single ticker and marks its tab active.
+  window.setFilter('PURR');
+  assert.match(doc.getElementById('fb-PURR').className, /active/);
+  assert.doesNotMatch(doc.getElementById('fb-IBIT').className, /active/);
+  const holdings = doc.getElementById('ncbwrap').innerHTML;
+  assert.match(holdings, /PURR/);
+  assert.doesNotMatch(holdings, /IBIT/);
+
+  // Deleting the filtered ticker's last trade falls back to ALL, not an empty view.
+  window.deleteTrade(2);
+  assert.strictEqual(doc.getElementById('fb-PURR'), null, 'vanished ticker has no tab');
+  assert.match(doc.getElementById('fb-ALL').className, /active/, 'filter falls back to ALL');
+  assert.match(doc.getElementById('ncbwrap').innerHTML, /IBIT/, 'remaining ticker still shows');
+});


### PR DESCRIPTION
Closes #97.

## Problem
Wheeler's filter bar shipped only a single **All Tickers** tab, so `setFilter` could never scope the view to an individual ticker — the reused filtering feature was inert on Wheeler.

## Change
- **`06-render-table.js`** — new `rFilterTabs()` derives the tab bar from the unique tickers in `trades[]` (Wheeler only), one tab per ticker with a stable `assetColor()` dot; active ticker gets an inline colored border. Crypto keeps its static fixed-roster fragment untouched.
- **`03-form-controls.js`** — `setFilter` toggles `active` over the actual rendered `.asset-tabs` buttons instead of a hardcoded `['ALL','BTC','ETH','HYPE','SOL']` list. Behavior-identical for crypto, works for any ticker set.
- **`08-render.js`** — `render()` calls `rFilterTabs()`, and resets a vanished filter to `ALL` (Wheeler only) so deleting a filtered ticker's last trade lands on All Tickers rather than an empty, tab-less view.

## Design choice
Per the issue's open question: crypto keeps its static fragment; only Wheeler renders dynamically — smallest change, zero risk to HyperWheel.

## Tests
`python3 build.py --check` clean (both artifacts), `npm test` 151 pass. Added an integration test covering data-derived tabs (IBIT/PURR), single-ticker scoping, and the delete-and-fall-back-to-ALL path.