### PR TITLE
Unify build fragment/app config into src/app-manifest.json (#98)

### DIFF
--- a/build.py
+++ b/build.py
@@ -22,6 +22,7 @@ import sys
 import subprocess
 import os
 import glob
+import json
 
 BASE = os.path.dirname(os.path.abspath(__file__))
 
@@ -102,26 +103,22 @@ def resolve_version(cwd=BASE):
 
 # Two apps share the platform-neutral core/ and each add their own JS dir +
 # HTML fragments. build.py emits a single-file artifact per app.
+#
+# The app/fragment config is the single source of truth in src/app-manifest.json,
+# read by both this file and test/helpers/assemble.js so the two never drift (#98).
+_MANIFEST = json.loads(read(os.path.join(BASE, 'src', 'app-manifest.json')))
+
+# Manifest stores output paths POSIX-style; normalise to the host separator.
 APPS = {
-    'crypto': {
-        'js_dir': 'crypto',
-        'title': 'HyperWheel',
-        'subtitle': 'WHEEL STRATEGY TRACKER',
-        'local': 'hyperwheel.html',
-        'public': os.path.join('public', 'index.html'),
-    },
-    'tradfi': {
-        'js_dir': 'tradfi',
-        'title': 'Wheeler',
-        'subtitle': 'TRADFI WHEEL TRACKER',
-        'local': 'wheeler.html',
-        'public': os.path.join('public', 'wheeler', 'index.html'),
-    },
+    app: {**cfg,
+          'local': os.path.normpath(cfg['local']),
+          'public': os.path.normpath(cfg['public'])}
+    for app, cfg in _MANIFEST['apps'].items()
 }
 
 # Body/head markers of the form {{FRAG:name}} are replaced with the app's
 # src/html/<js_dir>/<name>.html fragment. Every app must supply every fragment.
-FRAGMENTS = ('wallet_overlay', 'header_actions', 'filter_tabs', 'trade_form', 'footer')
+FRAGMENTS = tuple(_MANIFEST['fragments'])
 
 
 def _fill_fragments(template, app_dir):

--- a/src/app-manifest.json
+++ b/src/app-manifest.json
@@ -1,0 +1,19 @@
+{
+  "fragments": ["wallet_overlay", "header_actions", "filter_tabs", "trade_form", "footer"],
+  "apps": {
+    "crypto": {
+      "js_dir": "crypto",
+      "title": "HyperWheel",
+      "subtitle": "WHEEL STRATEGY TRACKER",
+      "local": "hyperwheel.html",
+      "public": "public/index.html"
+    },
+    "tradfi": {
+      "js_dir": "tradfi",
+      "title": "Wheeler",
+      "subtitle": "TRADFI WHEEL TRACKER",
+      "local": "wheeler.html",
+      "public": "public/wheeler/index.html"
+    }
+  }
+}

--- a/test/helpers/assemble.js
+++ b/test/helpers/assemble.js
@@ -1,15 +1,16 @@
 // Assembles the app body HTML the same way build.py does, so jsdom tests see
 // the real DOM (fragments substituted) rather than raw {{FRAG:...}} markers.
-// Mirrors build.py's FRAGMENTS list + APPS title/subtitle — keep in sync.
+// The fragment list + app title/subtitle come from src/app-manifest.json, the
+// same single source of truth build.py reads — no more keep-in-sync drift (#98).
 const fs = require('fs');
 const path = require('path');
 
 const ROOT = path.join(__dirname, '..', '..');
-const FRAGMENTS = ['wallet_overlay', 'header_actions', 'filter_tabs', 'trade_form', 'footer'];
-const APP_META = {
-  crypto: { title: 'HyperWheel', subtitle: 'WHEEL STRATEGY TRACKER' },
-  tradfi: { title: 'Wheeler', subtitle: 'TRADFI WHEEL TRACKER' },
-};
+const MANIFEST = JSON.parse(fs.readFileSync(path.join(ROOT, 'src', 'app-manifest.json'), 'utf8'));
+const FRAGMENTS = MANIFEST.fragments;
+const APP_META = Object.fromEntries(
+  Object.entries(MANIFEST.apps).map(([app, cfg]) => [app, { title: cfg.title, subtitle: cfg.subtitle }]),
+);
 
 function assembleBody(app = 'crypto') {
   let body = fs.readFileSync(path.join(ROOT, 'src', 'html', 'body.html'), 'utf8');


### PR DESCRIPTION
Closes #98.

## Problem
The fragment/app assembly config lived in two places that had to be kept in sync by hand:
- `build.py` — `FRAGMENTS` tuple + `APPS` (title/subtitle, js_dir, output paths)
- `test/helpers/assemble.js` — re-declared `FRAGMENTS` + `APP_META`

Adding or renaming a fragment or app required editing both (Shotgun Surgery). `assemble.js` even carried a "keep in sync" comment.

## Fix
Extract the config to a static **`src/app-manifest.json`**, read by both `build.py` and `assemble.js` as the single source of truth.

- Chosen over the issue's "build.py emits a manifest" option to avoid a build-before-test ordering dependency (CI runs the test job separately from the build, and the built artifacts are gitignored).
- No npm/bundler dependency — JSON parses natively in Python and Node.
- The two substitution *implementations* remain (unavoidable Python↔JS boundary), but the config that drifts is unified.
- `build.py` normalizes the POSIX-style output paths to the host separator.

## Verification
- `python3 build.py --check` — both apps build, JS syntax OK
- `npm test` — 151/151 pass