### PR TITLE
Ignore .vercel project dir and .env*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ options-*-analysis-prompt.md
 # Wheeler auth wizard — local captured secrets (never commit)
 .env
 .wheeler-auth.env
+.vercel
+.env*


### PR DESCRIPTION
Adds `.vercel` (created by `vercel link`) and `.env*` to .gitignore so the local Vercel link dir and any env files never get committed. Chore only.