### PR TITLE
Mobile: trade-table card layouts + touch/keyboard polish

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -129,6 +129,13 @@ body{font-family:var(--mono);background:var(--bg);color:var(--text);font-size:15
   .exp-cards{display:flex}
 }
 
+/* Mobile cards for the Trade Log tables (open + history) */
+.tlog-cards{display:none;flex-direction:column;gap:8px;padding:6px 0 2px}
+@media(max-width:600px){
+  #tlog .twrap{display:none}
+  #tlog .tlog-cards{display:flex}
+}
+
 /* SECTION */
 .sec{border-left:2px solid var(--green);background:var(--surface);padding:20px 24px}
 .sec-hd{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px}
@@ -306,7 +313,7 @@ tr.lot-child.la-sol:hover > td{background:rgba(153,69,255,.08)}
 .has-tip:hover .tip-ico,.has-tip:hover .ppnl-tip-ico{opacity:1;color:var(--text)}
 .ppnl-card.has-tip:hover{border-color:var(--mu)}
 .has-tip::after{content:attr(data-tip);position:absolute;left:50%;bottom:calc(100% + 8px);transform:translateX(-50%);background:#0c1119;color:var(--text);border:1px solid var(--bd);border-radius:8px;padding:8px 10px;font-family:var(--mono);font-size:.7rem;line-height:1.45;width:max-content;max-width:300px;white-space:normal;text-align:left;box-shadow:0 8px 24px rgba(0,0,0,.45);opacity:0;pointer-events:none;transition:opacity .12s ease;z-index:20}
-.has-tip:hover::after{opacity:1}
+.has-tip:hover::after,.has-tip.tip-open::after{opacity:1}
 /* Flip the popover below the anchor — for tips near the top of a section or
    inside an overflow:hidden container (e.g. the cpnl hero tiles). */
 .has-tip--below::after{bottom:auto;top:calc(100% + 8px)}
@@ -361,6 +368,7 @@ tr.lot-child.la-sol:hover > td{background:rgba(153,69,255,.08)}
   .fb{grid-template-columns:1fr}
   .header{padding:10px 12px}
   .hsub{display:none}
+  .wheeler-auth-email{display:none}
   .cpnl-hero-hd{padding:14px 14px 10px}
   .cpnl-hero-val{font-size:1.5rem}
   .cpnl-tile-total{font-size:1.5rem}

--- a/src/html/body.html
+++ b/src/html/body.html
@@ -103,6 +103,7 @@
     <div class="twrap">
       <table><thead><tr id="open-hdr"></tr></thead><tbody id="ttbody-open"></tbody></table>
     </div>
+    <div class="tlog-cards" id="tcards-open"></div>
     <!-- Position History -->
     <div class="tlog-sub-hd" style="margin-top:24px"><span>Position History</span><span id="hcnt" class="tlog-cnt"></span></div>
     <div class="hist-outchart" id="hist-outchart" style="display:none"></div>
@@ -127,6 +128,7 @@
     <div class="twrap">
       <table><thead><tr id="hist-hdr"></tr></thead><tbody id="ttbody-hist"></tbody></table>
     </div>
+    <div class="tlog-cards" id="tcards-hist"></div>
   </div>
 
 </div><!-- end content-col -->

--- a/src/js/core/06-render-table.js
+++ b/src/js/core/06-render-table.js
@@ -181,6 +181,69 @@ function _histRow(r) {
     + '</tr>';
 }
 
+// Mobile card mirrors of the open/history table rows (shown <600px in place of
+// the horizontally-scrolling tables). Reuse the .exp-card styling family.
+function _openCard(r) {
+  const typeBadge = '<span class="badge b' + r.type.toLowerCase() + '">' + r.type + '</span>';
+  const platBadge = r.platform === 'HSFC' ? '<span class="bplat bplat-hsfc">HSFC</span>' : '<span class="bplat bplat-rysk">RYSK</span>';
+  const aprStr = '<span style="font-weight:700;color:' + (r.annual > 0 ? 'var(--green)' : 'var(--mu2)') + '">'
+    + (r.annual !== null ? r.annual.toFixed(1) + '%' : '&mdash;') + '</span>';
+  const closeBtn = _isTradfi()
+    ? '<button class="btn-qa btn-qa-cls" onclick="openEditModal(' + r.id + ',\'CLOSED\')" title="Buy to close">Close ⊗</button>'
+    : '';
+  const actions = (r.type === 'CALL'
+    ? '<button class="btn-qa btn-qa-exp" onclick="quickOutcome(' + r.id + ',\'EXPIRED\')">Exp ✓</button>'
+      + '<button class="btn-qa btn-qa-cal" onclick="quickOutcome(' + r.id + ',\'CALLED\')">Called ↑</button>'
+    : '<button class="btn-qa btn-qa-exp" onclick="quickOutcome(' + r.id + ',\'EXPIRED\')">Exp ✓</button>'
+      + '<button class="btn-qa btn-qa-asg" onclick="quickOutcome(' + r.id + ',\'ASSIGNED\')">Asgn ↓</button>') + closeBtn;
+  return '<div class="exp-card">'
+    + '<div class="exp-card-row1">'
+    +   '<span class="exp-card-asset" style="color:' + assetColor(r.asset) + '">' + r.asset + '</span>'
+    +   typeBadge
+    +   '<span class="exp-card-dte">' + _liveDte(r.expiry) + '</span>'
+    +   _platCol(platBadge)
+    + '</div>'
+    + '<div class="exp-card-row2">'
+    +   '<div><span class="exp-card-lbl">Strike</span> $' + fmt(r.strike) + '</div>'
+    +   '<div><span class="exp-card-lbl">Size</span> ' + fmtSize(r.size, r.asset) + '</div>'
+    +   '<div><span class="exp-card-lbl">Prem</span> +$' + fmt(r.premium) + '</div>'
+    +   '<div><span class="exp-card-lbl">APR</span> ' + aprStr + '</div>'
+    + '</div>'
+    + '<div class="exp-card-row3"><div class="row-actions">' + actions
+    +   '<button class="btn-d" onclick="deleteTrade(' + r.id + ')" title="Delete">&#10005;</button></div></div>'
+    + '</div>';
+}
+
+function _histCard(r) {
+  const typeBadge = '<span class="badge b' + r.type.toLowerCase() + '">' + r.type + '</span>';
+  const platBadge = r.platform === 'HSFC' ? '<span class="bplat bplat-hsfc">HSFC</span>' : '<span class="bplat bplat-rysk">RYSK</span>';
+  const outBadge = '<span class="badge ' + outcomeBadge(r.outcome) + '">' + outcomeLabel(r) + '</span>';
+  const premHtml = r.outcome === 'CLOSED'
+    ? '+$' + fmt(r.premium - (r.closeCost || 0))
+    : '+$' + fmt(r.premium);
+  const corrBtn = r.outcome === 'EXPIRED' && r.type === 'CALL'
+    ? '<button class="btn-qa btn-qa-cal" onclick="quickOutcome(' + r.id + ',\'CALLED\')">Called ↑</button>'
+    : r.outcome === 'EXPIRED' && r.type === 'PUT'
+    ? '<button class="btn-qa btn-qa-asg" onclick="quickOutcome(' + r.id + ',\'ASSIGNED\')">Asgn ↓</button>'
+    : '';
+  return '<div class="exp-card">'
+    + '<div class="exp-card-row1">'
+    +   '<span class="exp-card-asset" style="color:' + assetColor(r.asset) + '">' + r.asset + '</span>'
+    +   typeBadge
+    +   '<span class="exp-card-dte">' + outBadge + '</span>'
+    +   _platCol(platBadge)
+    + '</div>'
+    + '<div class="exp-card-row2">'
+    +   '<div><span class="exp-card-lbl">Date</span> ' + r.date + '</div>'
+    +   '<div><span class="exp-card-lbl">Strike</span> $' + fmt(r.strike) + '</div>'
+    +   '<div><span class="exp-card-lbl">Size</span> ' + fmtSize(r.size, r.asset) + '</div>'
+    +   '<div><span class="exp-card-lbl">Prem</span> ' + premHtml + '</div>'
+    + '</div>'
+    + '<div class="exp-card-row3"><div class="row-actions">' + corrBtn
+    +   '<button class="btn-d" onclick="deleteTrade(' + r.id + ')" title="Delete">&#10005;</button></div></div>'
+    + '</div>';
+}
+
 function rStats(streams, lots, allRows, displayRows) {
   renderExpiryTable(allRows);
 }
@@ -326,12 +389,16 @@ function rTable(displayRows, streams, lots) {
   const histHdr  = document.getElementById('hist-hdr');
   const ocntEl   = document.getElementById('ocnt');
   const hcntEl   = document.getElementById('hcnt');
+  const openCards = document.getElementById('tcards-open');
+  const histCards = document.getElementById('tcards-hist');
 
   if (!displayRows.length) {
     if (openHdr)  openHdr.innerHTML  = _openHeaders();
     if (histHdr)  histHdr.innerHTML  = _histHeaders();
     if (openBody) openBody.innerHTML = '<tr><td colspan="11"><div class="empty"><div class="empty-icon">&#9678;</div><div class="empty-title">No trades logged yet</div><div class="empty-sub">Start by logging your first position \u2014 a PUT, CALL, or spot HOLDING. Your P&amp;L, net cost basis, and premium income will appear here automatically.</div><button class="empty-cta" onclick="openTradeDrawer()">+ LOG FIRST TRADE</button></div></td></tr>';
     if (histBody) histBody.innerHTML = '';
+    if (openCards) openCards.innerHTML = '';
+    if (histCards) histCards.innerHTML = '';
     ncWrap.innerHTML = ''; cntEl.textContent = '';
     if (ocntEl) ocntEl.textContent = '';
     if (hcntEl) hcntEl.textContent = '';
@@ -461,12 +528,18 @@ function rTable(displayRows, streams, lots) {
   if (openBody) openBody.innerHTML = sortedOpen.length
     ? sortedOpen.map(_openRow).join('')
     : '<tr><td colspan="11" style="padding:14px 12px;color:var(--mu);font-size:.75rem;text-align:center;font-family:var(--mono)">No open positions</td></tr>';
+  if (openCards) openCards.innerHTML = sortedOpen.length
+    ? sortedOpen.map(_openCard).join('')
+    : '<div class="exp-empty">No open positions</div>';
 
   // Position history
   const sortedHist = _sortRows(histRows, tSortHist);
   if (histBody) histBody.innerHTML = sortedHist.length
     ? sortedHist.map(_histRow).join('')
     : '<tr><td colspan="12" style="padding:14px 12px;color:var(--mu);font-size:.75rem;text-align:center;font-family:var(--mono)">No closed positions yet</td></tr>';
+  if (histCards) histCards.innerHTML = sortedHist.length
+    ? sortedHist.map(_histCard).join('')
+    : '<div class="exp-empty">No closed positions yet</div>';
 }
 
 function exportHistoryCSV() {

--- a/src/js/core/15-event-listeners.js
+++ b/src/js/core/15-event-listeners.js
@@ -4,3 +4,27 @@ document.addEventListener('keydown', function(e) {
   if (document.getElementById('edit-overlay').classList.contains('open')) { closeEditModal(); return; }
   if (document.getElementById('trade-drawer').classList.contains('open')) { closeTradeDrawer(); return; }
 });
+
+// Enter submits the open trade drawer (from any text/number input; date inputs
+// keep their native Enter behaviour). Clicks the drawer's single primary button
+// so it routes to whichever add function the app wired up.
+document.addEventListener('keydown', function(e) {
+  if (e.key !== 'Enter') return;
+  const drawer = document.getElementById('trade-drawer');
+  if (!drawer || !drawer.classList.contains('open')) return;
+  const t = e.target;
+  if (!t || t.tagName !== 'INPUT' || t.type === 'date') return;
+  e.preventDefault();
+  const btn = drawer.querySelector('.btn-p');
+  if (btn) btn.click();
+});
+
+// Touch devices can't hover, so tap toggles the styled tooltips (P&L lens hints).
+document.addEventListener('click', function(e) {
+  if (!window.matchMedia || !window.matchMedia('(hover:none)').matches) return;
+  const tip = e.target.closest ? e.target.closest('.has-tip') : null;
+  document.querySelectorAll('.has-tip.tip-open').forEach(function(el) {
+    if (el !== tip) el.classList.remove('tip-open');
+  });
+  if (tip) tip.classList.toggle('tip-open');
+});


### PR DESCRIPTION
Follow-up to #115. Continues the mobile-friendliness pass.

## Mobile UI
- **Trade Log tables → cards below 600px.** Open Positions and Position History now render as stacked cards on phones (mirroring the existing Expiring-This-Week card pattern) instead of a horizontally-scrolling table. New `#tcards-open` / `#tcards-hist` containers populated by `_openCard` / `_histCard`; CSS swaps table↔cards at ≤600px.
- **Tap-to-toggle tooltips on touch.** The styled P&L-lens tooltips were hover-only and dead on mobile — a tap now toggles them (guarded to `hover:none` devices).
- **Collapse signed-in email on ≤480px** so the wrapped header stays tidy (sign-out button remains).

## Smaller polish
- **Enter submits the trade drawer** from any text/number input (date inputs keep native Enter). Clicks the drawer's single primary button, so it routes to the right add function in both apps.

Skipped for now (noted to the user): sample-trade onboarding and `sk()` abbreviation of the P&L hero — the latter trades away dollar precision and the mobile font-shrink from #115 already handles overflow.

## Testing
`python3 build.py --check` green for both artifacts; `npm test` 163/163 pass. Card containers are siblings of the tbodies, so existing DOM-query tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)