### PR TITLE
Wheeler: quiet the Sign Out button (ghost variant)

### DIFF
--- a/src/js/tradfi/12-cloud-sync.js
+++ b/src/js/tradfi/12-cloud-sync.js
@@ -24,7 +24,7 @@ function _setAuthUI(authed, email) {
   if (authed) {
     el.innerHTML =
       '<span class="wheeler-auth-email" title="' + (email || '') + '">' + (email || 'signed in') + '</span>' +
-      '<button class="btn" onclick="wheelerSignOut()">[ SIGN OUT ]</button>';
+      '<button class="btn btn-g" onclick="wheelerSignOut()">[ SIGN OUT ]</button>';
   } else {
     el.innerHTML =
       '<button class="btn btn-p" onclick="wheelerSignIn()">[ SIGN IN WITH GOOGLE ]</button>';


### PR DESCRIPTION
The signed-in Sign Out button used a bare \`.btn\` class, which sets no background or color — so it fell back to the browser's default button chrome (light-gray fill, blue text), clashing with the header's outline aesthetic.

Switch it to the \`btn-g\` ghost variant (transparent, muted border/text, green on hover) to match the CONTRACTS/SHARES toggles. Sign-in stays \`btn-p\` (green primary CTA — it should stand out).

One-line change. \`build.py --check\` green, \`npm test\` 163/163 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)