### PR TITLE
Vercel: drop hardcoded outputDirectory for wheeler split

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,6 @@
       "main": false
     }
   },
-  "outputDirectory": "public",
   "framework": null,
   "headers": [
     {


### PR DESCRIPTION
Removes `"outputDirectory": "public"` from `vercel.json` so the new standalone **wheeler** Vercel project can override its Output Directory to `public/wheeler`.

Part of splitting into two sites:
- `hyperwheel.vercel.app` → serves `public/` (auto-detected via `framework: null`)
- `wheeler.vercel.app` → serves `public/wheeler/` (set in the wheeler project's dashboard settings)

HyperWheel behavior is unchanged: with no explicit `outputDirectory` and `framework: null`, Vercel defaults to serving `public/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)