### PR TITLE
Wheeler auth: fix post-login redirect on standalone site

### DIFF
--- a/api/auth/google.js
+++ b/api/auth/google.js
@@ -34,11 +34,15 @@ module.exports = async function handler(req, res) {
 
   const { code, state, action, error } = req.query;
 
+  // Where the app lives on this deployment: '/' when Wheeler is a standalone
+  // site (gowheeler.vercel.app), '/wheeler' when served under HyperWheel.
+  const appPath = process.env.WHEELER_APP_PATH || '/wheeler';
+
   // Logout — clear the session cookie and return to the app.
   if (action === 'logout') {
     res.setHeader('Set-Cookie', cookie(auth.SESSION_COOKIE, '', 0));
     res.statusCode = 302;
-    res.setHeader('Location', '/wheeler');
+    res.setHeader('Location', appPath);
     return res.end();
   }
 
@@ -75,7 +79,7 @@ module.exports = async function handler(req, res) {
         cookie(auth.STATE_COOKIE, '', 0),
       ]);
       res.statusCode = 302;
-      res.setHeader('Location', '/wheeler');
+      res.setHeader('Location', appPath);
       return res.end();
     } catch {
       return res.status(502).send('Sign-in failed. Please try again.');


### PR DESCRIPTION
After the two-site split (#118), Wheeler's OAuth handler still redirected to `/wheeler` after login/logout. On the standalone `gowheeler.vercel.app` the app lives at `/`, so users landed on a 404.

- Reads the redirect target from `WHEELER_APP_PATH` (set to `/` on the `gowheeler` project).
- Defaults to `/wheeler` so HyperWheel's `/wheeler` subpath is unchanged.

Note: the missing auth env vars on the fresh `gowheeler` project (the actual "auth not configured" error) were copied over separately via CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)