### PR TITLE
Retire /wheeler subpath on hyperwheel; redirect to gowheeler

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,14 @@
     }
   },
   "framework": null,
+  "redirects": [
+    {
+      "source": "/wheeler/:path*",
+      "has": [{ "type": "host", "value": "hyperwheel.vercel.app" }],
+      "destination": "https://gowheeler.vercel.app/:path*",
+      "permanent": false
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Wheeler now has its own standalone site (`gowheeler.vercel.app`). This redirects the legacy `hyperwheel.vercel.app/wheeler` path to it.

- Host-scoped to `hyperwheel.vercel.app` (via `has` host condition), so `gowheeler` is unaffected.
- `/wheeler/:path*` → `https://gowheeler.vercel.app/:path*`.
- Temporary (307) redirect to avoid hard browser caching if it ever needs reverting.

Follow-up: the six Wheeler-only env vars (Google OAuth, session secret, allow-list, Finnhub/TwelveData keys) were removed from the hyperwheel Vercel project via CLI, since Wheeler auth/quotes no longer run there. KV vars stay (HyperWheel holdings sync uses them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)