### PR TITLE
Wheeler: fetch spot for newly-added tickers without reload

### DIFF
--- a/src/js/tradfi/19-tradfi-form.js
+++ b/src/js/tradfi/19-tradfi-form.js
@@ -57,7 +57,9 @@ function wheelerAddTrade() {
   }
 
   trades.push(tradeObj);
-  save(); render(); clearForm();
+  save(); render();
+  fetchExpiryPrices();  // price any newly-added ticker without a page reload
+  clearForm();
   closeTradeDrawer();
   toast(asset + ' ' + sType.toLowerCase() + ' added');
   const tlog = document.getElementById('tlog');


### PR DESCRIPTION
Adding a holding mid-session showed `spot unavailable` until a page reload, because `wheelerAddTrade` only ran `save()/render()` while prices are fetched at boot. Now calls `fetchExpiryPrices()` after adding so new tickers get priced immediately.

- Confirmed: reload already populated the price, so the feed/API are fine — this just removes the reload requirement.
- Build + all 163 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)