### PR TITLE
Wheeler: add closeDate field for buy-to-close realisation date (#123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,9 @@ typecheck step — plain JS, no TS.
   premium: 150,             // premium collected (0 for HOLDING)
   outcome: 'OPEN',          // OPEN | EXPIRED | ASSIGNED | CALLED | CLOSED
   closeCost: 0,             // for CLOSED outcome (Hypersurface buy-to-close)
+  closeDate: '',            // realisation date for CLOSED (buy-to-close); empty
+                            // otherwise. computePnl buckets CLOSED realised P&L
+                            // on this date (falls back to expiry if unset)
   platform: 'RYSK',         // RYSK | HSFC | SPOT
   lotNum: 2,                // optional explicit lot for CALLs (else attaches to openLot)
   txHash: '0x…',            // present iff imported from chain-sync

--- a/docs/flows.html
+++ b/docs/flows.html
@@ -1,0 +1,676 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>HyperWheel — Module Flow Docs</title>
+  <style>
+    :root {
+      --bg: #0f0f13;
+      --surface: #1a1a24;
+      --border: #252535;
+      --text: #ddddf0;
+      --muted: #55556f;
+      --accent: #7c6af7;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-size: 13px;
+      display: flex;
+      height: 100vh;
+      overflow: hidden;
+    }
+    #sidebar {
+      width: 210px;
+      flex-shrink: 0;
+      background: var(--surface);
+      border-right: 1px solid var(--border);
+      overflow-y: auto;
+      padding-bottom: 20px;
+    }
+    .sidebar-hd {
+      padding: 14px 14px 8px;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--muted);
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 6px;
+    }
+    .flow-cat {
+      padding: 10px 14px 3px;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+    .flow-btn {
+      display: block;
+      width: 100%;
+      text-align: left;
+      padding: 7px 14px;
+      border: none;
+      background: none;
+      color: var(--text);
+      font-size: 12.5px;
+      cursor: pointer;
+      transition: background 0.1s;
+      border-left: 2px solid transparent;
+    }
+    .flow-btn:hover { background: rgba(255,255,255,0.04); }
+    .flow-btn.active {
+      background: rgba(124,106,247,0.12);
+      border-left-color: var(--accent);
+      color: #c4b5fd;
+    }
+    #main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      min-width: 0;
+    }
+    #graph-wrap {
+      flex: 1;
+      overflow: auto;
+    }
+    #panel {
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      padding: 12px 16px 14px;
+      min-height: 130px;
+      max-height: 170px;
+      overflow-y: auto;
+    }
+    #panel-hd {
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 9px;
+    }
+    #chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+      margin-bottom: 9px;
+    }
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 4px 9px 4px 4px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--bg);
+      font-size: 11.5px;
+      cursor: pointer;
+      transition: border-color 0.12s, background 0.12s;
+      white-space: nowrap;
+      font-family: ui-monospace, 'Cascadia Code', monospace;
+    }
+    .chip:hover { border-color: var(--accent); }
+    .chip.on { border-color: var(--accent); background: rgba(124,106,247,0.13); color: #c4b5fd; }
+    .chip-n {
+      width: 17px; height: 17px;
+      border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 9px; font-weight: 700;
+      background: var(--border);
+      flex-shrink: 0;
+      font-family: -apple-system, sans-serif;
+    }
+    .chip.on .chip-n { background: var(--accent); color: #fff; }
+    #note {
+      font-size: 12px;
+      color: #8888aa;
+      line-height: 1.55;
+      min-height: 20px;
+    }
+    #note strong { color: #d0c8ff; font-weight: 500; }
+    #empty { color: var(--muted); }
+    .hint {
+      margin-top: 6px;
+      font-size: 11px;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+
+<nav id="sidebar"></nav>
+
+<div id="main">
+  <div id="graph-wrap">
+    <svg id="g" xmlns="http://www.w3.org/2000/svg"
+         viewBox="0 0 960 570" width="960" height="570"
+         style="display:block;min-width:800px">
+      <defs>
+        <marker id="a0" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+          <path d="M0,1 L0,6 L7,3.5 z" fill="#7c6af7" opacity="0.65"/>
+        </marker>
+        <marker id="a1" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+          <path d="M0,1 L0,6 L7,3.5 z" fill="#c4b5fd"/>
+        </marker>
+        <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+          <feGaussianBlur stdDeviation="3.5" result="b"/>
+          <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+        </filter>
+      </defs>
+      <g id="glabels"></g>
+      <g id="garrows"></g>
+      <g id="gmods"></g>
+      <g id="gnums"></g>
+    </svg>
+  </div>
+  <div id="panel">
+    <div id="panel-hd">Steps</div>
+    <div id="empty">← Select a flow</div>
+    <div id="chips" style="display:none"></div>
+    <div id="note" style="display:none"></div>
+    <div class="hint" id="hint" style="display:none">Click a chip to focus · ← → arrow keys to step</div>
+  </div>
+</div>
+
+<script>
+// ── constants ──────────────────────────────────────────────────────────────
+
+const BW = 128, BH = 30;
+
+const GC = {
+  boot:    '#6366f1',
+  state:   '#8b5cf6',
+  ui:      '#3b82f6',
+  crud:    '#f59e0b',
+  compute: '#10b981',
+  render:  '#14b8a6',
+  sync:    '#f97316',
+};
+
+// Row y values (top of box): 28, 103, 178, 253, 328, 403, 478  (75px pitch)
+const MODS = [
+  // Boot
+  { id:'boot',         label:'17-boot',           g:'boot',    x:20,  y:28  },
+  { id:'events',       label:'15-events',          g:'boot',    x:165, y:28  },
+  { id:'clock',        label:'16-clock',           g:'boot',    x:310, y:28  },
+  // State / utils
+  { id:'state',        label:'01-state',           g:'state',   x:20,  y:103 },
+  { id:'outcomes',     label:'01a-outcomes',       g:'state',   x:165, y:103 },
+  { id:'utils',        label:'02-utils',           g:'state',   x:310, y:103 },
+  // UI / modals
+  { id:'drawer',       label:'09-drawer',          g:'ui',      x:20,  y:178 },
+  { id:'wallet',       label:'11-wallet',          g:'ui',      x:162, y:178 },
+  { id:'form',         label:'03-form-controls',   g:'ui',      x:304, y:178 },
+  { id:'edit',         label:'13-edit-modal',      g:'ui',      x:446, y:178 },
+  { id:'merge-modal',  label:'14-merge-modal',     g:'ui',      x:588, y:178 },
+  { id:'reset',        label:'10-reset-modal',     g:'ui',      x:730, y:178 },
+  // CRUD
+  { id:'trade-crud',   label:'04-trade-crud',      g:'crud',    x:20,  y:253 },
+  { id:'lot-engine',   label:'04b-lot-engine',     g:'crud',    x:215, y:253 },
+  // Compute
+  { id:'compute',      label:'05-compute',         g:'compute', x:20,  y:328 },
+  { id:'merge-lots',   label:'05a-merge-lots',     g:'compute', x:188, y:328 },
+  { id:'pnl',          label:'05b-pnl',            g:'compute', x:356, y:328 },
+  { id:'dist',         label:'05c-dist',           g:'compute', x:524, y:328 },
+  // Render
+  { id:'render',       label:'08-render',          g:'render',  x:20,  y:403 },
+  { id:'table',        label:'06-render-table',    g:'render',  x:188, y:403 },
+  { id:'out-chart',    label:'06a-outcome-chart',  g:'render',  x:356, y:403 },
+  { id:'charts',       label:'07-charts',          g:'render',  x:524, y:403 },
+  // Sync
+  { id:'cloud-sync',   label:'12-cloud-sync',      g:'sync',    x:20,  y:490 },
+  { id:'chain-sync',   label:'18-chain-sync',      g:'sync',    x:215, y:490 },
+  { id:'chain-apply',  label:'18b-chain-apply',    g:'sync',    x:455, y:490 },
+];
+
+const MM = {};
+MODS.forEach(m => { MM[m.id] = m; });
+
+const GROUP_ROWS = [
+  { g:'boot',    label:'Boot / Events', y:12  },
+  { g:'state',   label:'State & Utils', y:87  },
+  { g:'ui',      label:'UI / Modals',   y:162 },
+  { g:'crud',    label:'Trade CRUD',     y:237 },
+  { g:'compute', label:'Compute',        y:312 },
+  { g:'render',  label:'Render',         y:387 },
+  { g:'sync',    label:'Sync',           y:474 },
+];
+
+// ── flows ──────────────────────────────────────────────────────────────────
+
+const FLOWS = [
+  {
+    id: 'new-user-boot', cat: 'Bootstrap', label: 'First boot — new user',
+    steps: [
+      { from:'boot',       to:'state',      fn:'trades = []',         note:'Boot IIFE reads hw_holdings from localStorage — empty for a new user, so trades[] starts empty.' },
+      { from:'boot',       to:'wallet',     fn:'showWalletPopup()',   note:'No hw_wallet key found → wallet popup is shown so user can enter their address.' },
+      { from:'wallet',     to:'utils',      fn:'saveWallet(addr)',    note:'User submits address → saved to localStorage as hw_wallet (lowercased).' },
+      { from:'boot',       to:'render',     fn:'render()',            note:'Initial render with empty trades array — UI draws empty state.' },
+      { from:'boot',       to:'table',      fn:'fetchExpiryPrices()', note:'CoinGecko prices fetched for expiry table enrichment; re-calls render() on success.' },
+      { from:'boot',       to:'cloud-sync', fn:'cloudPull()',         note:'Pulls HOLDING trades from /api/sync KV store if remote timestamp is newer than local.' },
+      { from:'boot',       to:'chain-sync', fn:'autoLoadChain()',     note:'Chain sync starts (skipped if serving over file:// — hasProxy() returns false).' },
+    ]
+  },
+  {
+    id: 'return-boot', cat: 'Bootstrap', label: 'Boot — returning user',
+    steps: [
+      { from:'boot',       to:'state',      fn:'JSON.parse(localStorage)', note:'trades[] hydrated from hw_holdings in localStorage.' },
+      { from:'boot',       to:'render',     fn:'render()',                  note:'Full render with existing trades — tables, charts, lots all drawn.' },
+      { from:'boot',       to:'table',      fn:'fetchExpiryPrices()',       note:'CoinGecko prices fetched; re-renders expiry table with live DTE enrichment.' },
+      { from:'boot',       to:'cloud-sync', fn:'cloudPull()',               note:'Pulls HOLDINGs if cloud timestamp newer; replaces local data and re-renders.' },
+      { from:'boot',       to:'chain-sync', fn:'autoLoadChain()',           note:'Stale-OPEN detection + full Rysk/Hypersurface sync runs on every boot.' },
+    ]
+  },
+  {
+    id: 'add-holding', cat: 'Trade CRUD', label: 'Add new HOLDING',
+    steps: [
+      { from:'drawer',     to:'form',       fn:'openTradeDrawer()',         note:'Drawer opens; 09-drawer calls focusForm(). type=HOLDING pre-selected.' },
+      { from:'form',       to:'trade-crud', fn:'addTrade()',                note:'Form values collected — new trade object (type=HOLDING, outcome=OPEN) pushed to trades[].' },
+      { from:'trade-crud', to:'utils',      fn:'save()',                    note:'trades[] serialized to hw_holdings in localStorage; scheduleCloudPush() queued.' },
+      { from:'utils',      to:'cloud-sync', fn:'scheduleCloudPush()',       note:'Debounced 300ms — pushes HOLDING trades to /api/sync keyed by wallet address.' },
+      { from:'utils',      to:'render',     fn:'render()',                  note:'Full re-render triggered.' },
+      { from:'render',     to:'compute',    fn:'compute()',                 note:'HOLDING opens a new lot at costBasis = strike via lotEngine.' },
+      { from:'compute',    to:'lot-engine', fn:'lotEngine(assetTrades)',    note:'Returns {lots, portfolioPnl, portfolioPremiums, tradeAccounting}. New lot added.' },
+      { from:'render',     to:'table',      fn:'rStats() + rTable()',       note:'Holdings section updated — new lot appears with net cost and unrealised P&L.' },
+    ]
+  },
+  {
+    id: 'sell-put', cat: 'Trade CRUD', label: 'Sell a PUT',
+    steps: [
+      { from:'drawer',     to:'form',       fn:'openTradeDrawer()',         note:'Drawer opens; user selects type=PUT, fills asset/strike/expiry/premium. autoDTE() suggests expiry.' },
+      { from:'form',       to:'trade-crud', fn:'addTrade()',                note:'PUT trade created (outcome=OPEN), pushed to trades[].' },
+      { from:'trade-crud', to:'utils',      fn:'save()',                    note:'Persisted to localStorage. Cloud push NOT triggered — options are local-only.' },
+      { from:'utils',      to:'render',     fn:'render()',                  note:'Re-render triggered.' },
+      { from:'render',     to:'compute',    fn:'compute()',                 note:'PUT goes to portfolioPremiums only — no lot opened for an unassigned PUT.' },
+      { from:'compute',    to:'lot-engine', fn:'lotEngine(assetTrades)',    note:'PUT netPrem goes to portfolioPremiums; any existing lots remain unchanged.' },
+      { from:'render',     to:'table',      fn:'rStats() + rTable()',       note:'New PUT appears in Open Positions table.' },
+    ]
+  },
+  {
+    id: 'assign-put', cat: 'Trade CRUD', label: 'Assign a PUT',
+    steps: [
+      { from:'table',      to:'trade-crud', fn:'quickOutcome("ASSIGNED")', note:'User clicks Assign on an open PUT row. outcome updated in-place in trades[].' },
+      { from:'trade-crud', to:'utils',      fn:'save()',                   note:'Updated trades[] persisted. Cloud push NOT triggered — options are local-only.' },
+      { from:'utils',      to:'render',     fn:'render()',                 note:'Re-render triggered.' },
+      { from:'render',     to:'compute',    fn:'compute()',                note:'ASSIGNED PUT now opens a new lot. PUT premium is credited to the lot\'s lotPremiums.' },
+      { from:'compute',    to:'lot-engine', fn:'lotEngine(assetTrades)',   note:'New lot: costBasis=strike, lotPremiums=put netPrem. netCost = costBasis − (lotPremiums/size).' },
+      { from:'render',     to:'table',      fn:'rStats() + rTable()',      note:'PUT moves to history. New lot appears in Holdings with reduced net cost.' },
+    ]
+  },
+  {
+    id: 'sell-call', cat: 'Trade CRUD', label: 'Sell a CALL on a lot',
+    steps: [
+      { from:'drawer',     to:'form',       fn:'openTradeDrawer()',         note:'User selects type=CALL. autoDTE() suggests expiry. Lot picker populated.' },
+      { from:'form',       to:'form',       fn:'refreshLotPicker()',        note:'Dropdown shows open lots for selected asset; user picks lotNum to attach the call to.' },
+      { from:'form',       to:'trade-crud', fn:'addTrade()',                note:'CALL trade with lotNum created, pushed to trades[].' },
+      { from:'trade-crud', to:'utils',      fn:'save()',                    note:'Persisted to localStorage.' },
+      { from:'utils',      to:'render',     fn:'render()',                  note:'Re-render triggered.' },
+      { from:'render',     to:'compute',    fn:'compute()',                 note:'CALL attaches to lot by lotNum (or openLot). netPrem accrues to lot.lotPremiums.' },
+      { from:'compute',    to:'lot-engine', fn:'lotEngine(assetTrades)',    note:'Lot netCost decreases: netCost = costBasis − (lotPremiums / size).' },
+      { from:'render',     to:'table',      fn:'rStats() + rTable()',       note:'Holdings card shows reduced net cost. CALL appears in Open Positions.' },
+    ]
+  },
+  {
+    id: 'expire-call', cat: 'Trade CRUD', label: 'Expire / call a position',
+    steps: [
+      { from:'table',      to:'trade-crud', fn:'quickOutcome("EXPIRED")',   note:'User clicks EXPIRED on an open CALL or PUT. outcome updated in trades[].' },
+      { from:'trade-crud', to:'utils',      fn:'save()',                    note:'Persisted to localStorage.' },
+      { from:'utils',      to:'render',     fn:'render()',                  note:'Re-render triggered.' },
+      { from:'render',     to:'compute',    fn:'compute()',                 note:'EXPIRED CALL: lot stays open, premium already counted. CALLED: strike*calledSize credited to portfolioPnl, lot reduced/closed.' },
+      { from:'compute',    to:'lot-engine', fn:'lotEngine(assetTrades)',    note:'For CALLED outcome: lot size reduced by calledSize. If fully called, lot removed from active lots.' },
+      { from:'render',     to:'table',      fn:'rStats() + rTable()',       note:'Trade moves from Open Positions to Position History.' },
+    ]
+  },
+  {
+    id: 'edit-trade', cat: 'Trade CRUD', label: 'Edit a trade',
+    steps: [
+      { from:'table',      to:'edit',       fn:'openEditModal(id)',          note:'Edit icon clicked. Trade found by id; fields (ef-date, ef-strike, ef-size, ef-premium, ef-outcome, ef-expiry, ef-dte, ef-notes) populated.' },
+      { from:'edit',       to:'trade-crud', fn:'saveEdit()',                 note:'Updated field values written back to the trade object in trades[] matched by id.' },
+      { from:'trade-crud', to:'utils',      fn:'save()',                     note:'Persisted to localStorage.' },
+      { from:'utils',      to:'render',     fn:'render()',                   note:'Re-render triggered.' },
+      { from:'render',     to:'compute',    fn:'compute()',                  note:'All lots and P&L recomputed from scratch with updated trade data.' },
+      { from:'render',     to:'table',      fn:'rStats() + rTable()',        note:'Tables updated to reflect edited values.' },
+    ]
+  },
+  {
+    id: 'merge-lots', cat: 'Trade CRUD', label: 'Merge open lots',
+    steps: [
+      { from:'table',      to:'merge-modal', fn:'openMergeModal(asset)',      note:'Merge button appears when an asset has >1 open lot. Modal shows preview of the merged result.' },
+      { from:'merge-modal', to:'merge-lots', fn:'mergeOpenLots(trades, asset)', note:'Size-weighted costBasis, summed lotPremiums, earliest opener kept, CALL lotNum cleared.' },
+      { from:'merge-lots', to:'state',       fn:'trades = result',            note:'Global trades[] replaced with the merged result returned from mergeOpenLots.' },
+      { from:'merge-modal', to:'utils',      fn:'save()',                     note:'Persisted to localStorage; cloud push queued.' },
+      { from:'utils',      to:'render',      fn:'render()',                   note:'Re-render triggered.' },
+      { from:'render',     to:'compute',     fn:'compute()',                  note:'Now a single lot per asset; netCost recalculated from merged costBasis and lotPremiums.' },
+      { from:'render',     to:'table',       fn:'rStats() + rTable()',        note:'Holdings shows single merged lot.' },
+    ]
+  },
+  {
+    id: 'chain-rysk', cat: 'Chain Sync', label: 'Chain sync — Rysk',
+    steps: [
+      { from:'boot',       to:'chain-sync',  fn:'autoLoadChain()',            note:'Boot calls autoLoadChain() if wallet present and proxy available (not file://).' },
+      { from:'chain-sync', to:'chain-sync',  fn:'syncRysk(addr)',             note:'Two REST calls via /api/chain-sync proxy: positions (all trades) + expiry-prices per underlying token.' },
+      { from:'chain-sync', to:'chain-apply', fn:'applyImportedTrades()',      note:'Dedupes by txHash against hw_synced_v1. Splits into openTrades/closeTrades, applies via applyCloseTrade.' },
+      { from:'chain-apply', to:'chain-sync', fn:'{added, closedCount}',       note:'Returns counts; chain-sync proceeds to outcome resolution with settlement prices.' },
+      { from:'chain-sync', to:'state',       fn:'resolveRyskOutcomes()',      note:'On-chain Chainlink oracle prices compared to strikes: PUT price≤strike→ASSIGNED, CALL price≥strike→CALLED.' },
+      { from:'chain-sync', to:'utils',       fn:'save()',                     note:'Updated trades[] + synced IDs (hw_synced_v1) persisted to localStorage.' },
+      { from:'utils',      to:'render',      fn:'render()',                   note:'UI updated with imported and resolved trades.' },
+    ]
+  },
+  {
+    id: 'chain-hsfc', cat: 'Chain Sync', label: 'Chain sync — Hypersurface',
+    steps: [
+      { from:'boot',       to:'chain-sync',  fn:'autoLoadChain()',            note:'autoLoadChain() runs syncHypersurface() after Rysk sync completes.' },
+      { from:'chain-sync', to:'chain-sync',  fn:'syncHypersurface(addr)',     note:'Two GraphQL POSTs via proxy: trades query (bought/sold legs) + positions query (amount_lt:"0" = shorts, checks redeemActions for exercise).' },
+      { from:'chain-sync', to:'chain-apply', fn:'applyImportedTrades()',      note:'Dedupes by txHash. Applies open/close trades; CLOSED outcome handled by applyCloseTrade.' },
+      { from:'chain-apply', to:'chain-sync', fn:'{added, closedCount}',       note:'Returns counts; chain-sync proceeds to outcome resolution.' },
+      { from:'chain-sync', to:'state',       fn:'resolveHsfcOutcomes()',      note:'redeemActions non-empty → ASSIGNED or CALLED. Empty → EXPIRED. Matched by asset+expiry+strike+type.' },
+      { from:'chain-sync', to:'utils',       fn:'save()',                     note:'Persisted to localStorage.' },
+      { from:'utils',      to:'render',      fn:'render()',                   note:'UI updated with Hypersurface trades and resolved outcomes.' },
+    ]
+  },
+  {
+    id: 'cloud-sync', cat: 'Cloud Sync', label: 'Cloud push / pull',
+    steps: [
+      { from:'utils',      to:'cloud-sync',  fn:'scheduleCloudPush()',        note:'Called from save() on every trades[] mutation; debounced 300ms.' },
+      { from:'cloud-sync', to:'cloud-sync',  fn:'cloudPush()',               note:'Filters trades to type===HOLDING only; POSTs to /api/sync keyed by hw_wallet.' },
+      { from:'cloud-sync', to:'table',       fn:'#footer-cloud status',      note:'Status indicator updated: push → ok, or err. Toast fires on error.' },
+      { from:'boot',       to:'cloud-sync',  fn:'cloudPull()',               note:'On boot: GETs /api/sync. If remoteTs > localTs, replaces local HOLDINGs.' },
+      { from:'cloud-sync', to:'state',       fn:'_suppressPush + trades[]',  note:'suppressPush flag prevents echo-push while overwriting local HOLDINGs with remote data.' },
+      { from:'cloud-sync', to:'render',      fn:'render()',                  note:'Re-render after pull. Toast fires if new data arrived.' },
+    ]
+  },
+  {
+    id: 'pnl-compute', cat: 'Compute', label: 'P&L computation flow',
+    steps: [
+      { from:'render',     to:'compute',    fn:'compute(assetFilter)',        note:'render() calls compute() first. Groups trades by asset, calls lotEngine per asset.' },
+      { from:'compute',    to:'lot-engine', fn:'lotEngine(assetTrades)',      note:'Returns {lots, portfolioPnl, portfolioPremiums, tradeAccounting}. Pure; dual-exported.' },
+      { from:'render',     to:'pnl',        fn:'computePnl(trades, filter, prices)', note:'Called from rCharts(). Cash-flow lens: realised = Σ settled netPrem + Σ (strike−costBasis)×calledSize.' },
+      { from:'pnl',        to:'charts',     fn:'{realised, unrealised, realisedSeries, realisedByMonth}', note:'rCharts consumes this for hero cumulative chart + Premium P&L Total tab tile.' },
+      { from:'render',     to:'dist',       fn:'outcomeDistribution(trades, filter)', note:'Called from rOutcomeChart(). Counts and premiums grouped by outcome.' },
+      { from:'dist',       to:'out-chart',  fn:'[{outcome, count, premium}]', note:'rOutcomeChart renders horizontal treemap. Cells click to toggle setHistOutcome filter.' },
+    ]
+  },
+];
+
+// ── geometry helpers ────────────────────────────────────────────────────────
+
+function cx(m) { return m.x + BW / 2; }
+function cy(m) { return m.y + BH / 2; }
+
+function edgePt(src, dst) {
+  const sx = cx(src), sy = cy(src);
+  const dx = cx(dst) - sx, dy = cy(dst) - sy;
+  const hw = BW / 2, hh = BH / 2;
+  if (dx === 0 && dy === 0) return { x: sx, y: sy };
+  if (Math.abs(dy) * hw >= Math.abs(dx) * hh) {
+    const f = hh / Math.abs(dy);
+    return dy > 0
+      ? { x: sx + dx * f, y: src.y + BH }
+      : { x: sx + dx * f, y: src.y };
+  } else {
+    const f = hw / Math.abs(dx);
+    return dx > 0
+      ? { x: src.x + BW, y: sy + dy * f }
+      : { x: src.x,      y: sy + dy * f };
+  }
+}
+
+function makePath(fid, tid) {
+  if (fid === tid) {
+    // Self-loop above box
+    const m = MM[fid]; if (!m) return '';
+    const bx = m.x + BW * 0.65, by = m.y;
+    return `M ${bx} ${by} C ${bx+28} ${by-28}, ${bx+48} ${by-28}, ${bx+36} ${by}`;
+  }
+  const src = MM[fid], dst = MM[tid];
+  if (!src || !dst) return '';
+  const s = edgePt(src, dst), e = edgePt(dst, src);
+  const ddx = e.x - s.x, ddy = e.y - s.y;
+  const len = Math.sqrt(ddx * ddx + ddy * ddy) || 1;
+  // Slight lateral bend to avoid overlapping straight lines
+  const bend = Math.min(40, len * 0.25);
+  const px = -ddy / len * bend * 0.4;
+  const py =  ddx / len * bend * 0.4;
+  const c1x = s.x + ddx * 0.33 + px, c1y = s.y + ddy * 0.33 + py;
+  const c2x = s.x + ddx * 0.66 + px, c2y = s.y + ddy * 0.66 + py;
+  return `M ${s.x.toFixed(1)} ${s.y.toFixed(1)} C ${c1x.toFixed(1)} ${c1y.toFixed(1)}, ${c2x.toFixed(1)} ${c2y.toFixed(1)}, ${e.x.toFixed(1)} ${e.y.toFixed(1)}`;
+}
+
+// ── SVG rendering ───────────────────────────────────────────────────────────
+
+function svgEl(tag, attrs) {
+  const el = document.createElementNS('http://www.w3.org/2000/svg', tag);
+  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+  return el;
+}
+
+function renderGroupLabels() {
+  const g = document.getElementById('glabels');
+  g.innerHTML = '';
+  GROUP_ROWS.forEach(row => {
+    g.appendChild(svgEl('text', {
+      x: 20, y: row.y,
+      fill: GC[row.g],
+      'font-size': 9.5,
+      'font-weight': 700,
+      'font-family': '-apple-system, sans-serif',
+      'letter-spacing': '0.07em',
+      opacity: 0.45,
+    })).textContent = row.label.toUpperCase();
+  });
+}
+
+function renderModules() {
+  const g = document.getElementById('gmods');
+  g.innerHTML = '';
+  MODS.forEach(m => {
+    const col = GC[m.g];
+    g.appendChild(svgEl('rect', {
+      id: `r-${m.id}`, x: m.x, y: m.y, width: BW, height: BH, rx: 6,
+      fill: '#1a1a24', stroke: col, 'stroke-width': 1.5, opacity: 0.35,
+    }));
+    const t = g.appendChild(svgEl('text', {
+      id: `t-${m.id}`,
+      x: m.x + BW / 2, y: m.y + BH / 2,
+      fill: col, opacity: 0.45,
+      'font-size': 10.5, 'font-weight': 500,
+      'font-family': 'ui-monospace, "Cascadia Code", monospace',
+      'dominant-baseline': 'middle', 'text-anchor': 'middle',
+    }));
+    t.textContent = m.label;
+  });
+}
+
+function setModState(id, state) {
+  // state: 'dim' | 'normal' | 'active'
+  const r = document.getElementById(`r-${id}`);
+  const t = document.getElementById(`t-${id}`);
+  if (!r || !t) return;
+  const col = GC[MM[id]?.g] || '#888';
+  if (state === 'dim') {
+    r.setAttribute('opacity', 0.12); r.setAttribute('stroke-width', 1); r.removeAttribute('filter');
+    t.setAttribute('opacity', 0.15);
+  } else if (state === 'normal') {
+    r.setAttribute('opacity', 0.65); r.setAttribute('stroke-width', 1.5); r.removeAttribute('filter');
+    t.setAttribute('opacity', 0.75);
+  } else {
+    r.setAttribute('opacity', 1); r.setAttribute('stroke-width', 2.5); r.setAttribute('filter', 'url(#glow)');
+    t.setAttribute('opacity', 1);
+  }
+}
+
+function resetMods() {
+  MODS.forEach(m => {
+    const r = document.getElementById(`r-${m.id}`);
+    const t = document.getElementById(`t-${m.id}`);
+    if (r) { r.setAttribute('opacity', 0.35); r.setAttribute('stroke-width', 1.5); r.removeAttribute('filter'); }
+    if (t) t.setAttribute('opacity', 0.45);
+  });
+}
+
+function drawFlow(flow, focusStep) {
+  // Dim all mods
+  MODS.forEach(m => setModState(m.id, 'dim'));
+
+  // Collect involved mods
+  const involved = new Set();
+  flow.steps.forEach(s => { involved.add(s.from); involved.add(s.to); });
+  involved.forEach(id => setModState(id, 'normal'));
+
+  // Active step mods
+  if (focusStep !== null) {
+    const s = flow.steps[focusStep];
+    if (s) { setModState(s.from, 'active'); setModState(s.to, 'active'); }
+  }
+
+  // Draw arrows
+  const ag = document.getElementById('garrows');
+  const ng = document.getElementById('gnums');
+  ag.innerHTML = ''; ng.innerHTML = '';
+
+  const purple = '#7c6af7';
+
+  flow.steps.forEach((step, i) => {
+    const isActive = focusStep === i;
+    const isDim = focusStep !== null && !isActive;
+    const d = makePath(step.from, step.to);
+    if (!d) return;
+
+    const path = ag.appendChild(svgEl('path', {
+      d, fill: 'none',
+      stroke: isActive ? '#c4b5fd' : purple,
+      'stroke-width': isActive ? 2.5 : 1.5,
+      opacity: isDim ? 0.15 : isActive ? 1 : 0.55,
+      'marker-end': `url(#${isActive ? 'a1' : 'a0'})`,
+    }));
+    if (isActive) path.setAttribute('filter', 'url(#glow)');
+
+    // Number badge at curve midpoint (skip self-loops)
+    if (step.from !== step.to) {
+      const src = MM[step.from], dst = MM[step.to];
+      if (src && dst) {
+        const s = edgePt(src, dst), e = edgePt(dst, src);
+        const mx = (s.x + e.x) / 2, my = (s.y + e.y) / 2;
+        const op = isDim ? 0.15 : 1;
+
+        ng.appendChild(svgEl('circle', {
+          cx: mx, cy: my, r: 9,
+          fill: isActive ? '#7c6af7' : '#1f1f2e',
+          stroke: isActive ? '#c4b5fd' : '#3a3a55',
+          'stroke-width': 1, opacity: op,
+        }));
+
+        const nt = ng.appendChild(svgEl('text', {
+          x: mx, y: my,
+          fill: isActive ? '#fff' : '#8888b0',
+          'font-size': 9, 'font-weight': 700,
+          'font-family': '-apple-system, sans-serif',
+          'dominant-baseline': 'middle', 'text-anchor': 'middle',
+          opacity: op,
+        }));
+        nt.textContent = i + 1;
+      }
+    }
+  });
+}
+
+// ── panel ───────────────────────────────────────────────────────────────────
+
+function renderPanel(flow, focusStep) {
+  const empty = document.getElementById('empty');
+  const chipsDiv = document.getElementById('chips');
+  const noteDiv = document.getElementById('note');
+  const hintDiv = document.getElementById('hint');
+
+  if (!flow) {
+    empty.style.display = ''; chipsDiv.style.display = 'none';
+    noteDiv.style.display = 'none'; hintDiv.style.display = 'none';
+    return;
+  }
+
+  empty.style.display = 'none';
+  chipsDiv.style.display = 'flex';
+  noteDiv.style.display = '';
+  hintDiv.style.display = '';
+
+  chipsDiv.innerHTML = flow.steps.map((s, i) => `
+    <div class="chip ${focusStep === i ? 'on' : ''}" onclick="selectStep(${i})">
+      <span class="chip-n">${i + 1}</span>
+      <span>${s.fn}</span>
+    </div>
+  `).join('');
+
+  if (focusStep !== null) {
+    const s = flow.steps[focusStep];
+    const sl = MM[s.from]?.label || s.from;
+    const dl = MM[s.to]?.label || s.to;
+    noteDiv.innerHTML = `<strong>${sl}</strong> → <strong>${dl}</strong>: ${s.note}`;
+  } else {
+    noteDiv.textContent = 'Click a step chip to focus it.';
+  }
+}
+
+// ── sidebar ─────────────────────────────────────────────────────────────────
+
+function renderSidebar() {
+  const cats = {};
+  FLOWS.forEach(f => { (cats[f.cat] = cats[f.cat] || []).push(f); });
+  const nav = document.getElementById('sidebar');
+  let html = '<div class="sidebar-hd">HyperWheel Flows</div>';
+  Object.entries(cats).forEach(([cat, flows]) => {
+    html += `<div class="flow-cat">${cat}</div>`;
+    flows.forEach(f => {
+      html += `<button class="flow-btn" data-id="${f.id}" onclick="selectFlow('${f.id}')">${f.label}</button>`;
+    });
+  });
+  nav.innerHTML = html;
+}
+
+// ── state ───────────────────────────────────────────────────────────────────
+
+let curFlowId = null, curStep = null;
+
+function selectFlow(id) {
+  curFlowId = id; curStep = null;
+  document.querySelectorAll('.flow-btn').forEach(b => b.classList.toggle('active', b.dataset.id === id));
+  const flow = FLOWS.find(f => f.id === id);
+  drawFlow(flow, null);
+  renderPanel(flow, null);
+}
+
+function selectStep(i) {
+  curStep = curStep === i ? null : i;
+  const flow = FLOWS.find(f => f.id === curFlowId);
+  if (flow) { drawFlow(flow, curStep); renderPanel(flow, curStep); }
+}
+
+document.addEventListener('keydown', e => {
+  if (!curFlowId) return;
+  const flow = FLOWS.find(f => f.id === curFlowId);
+  if (!flow) return;
+  if (e.key === 'ArrowRight') {
+    curStep = curStep === null ? 0 : Math.min(curStep + 1, flow.steps.length - 1);
+    drawFlow(flow, curStep); renderPanel(flow, curStep);
+  } else if (e.key === 'ArrowLeft') {
+    curStep = curStep === null ? 0 : Math.max(curStep - 1, 0);
+    drawFlow(flow, curStep); renderPanel(flow, curStep);
+  } else if (e.key === 'Escape') {
+    curStep = null;
+    drawFlow(flow, null); renderPanel(flow, null);
+  }
+});
+
+// ── init ────────────────────────────────────────────────────────────────────
+
+renderSidebar();
+renderGroupLabels();
+renderModules();
+</script>
+</body>
+</html>

--- a/src/html/tradfi/trade_form.html
+++ b/src/html/tradfi/trade_form.html
@@ -53,7 +53,8 @@
       </div>
     </div>
     <div class="fb" id="field-closecost" style="display:none">
-      <div class="field fi-full"><label>Close Cost ($)</label><input type="number" id="f-closecost" placeholder="40" step="1"><span style="font-size:.65rem;color:var(--mu);font-family:var(--mono);margin-top:2px">Buy-to-close cost &mdash; subtracted from premium</span></div>
+      <div class="field"><label>Close Cost ($)</label><input type="number" id="f-closecost" placeholder="40" step="1"><span style="font-size:.65rem;color:var(--mu);font-family:var(--mono);margin-top:2px">Buy-to-close cost &mdash; subtracted from premium</span></div>
+      <div class="field"><label>Close Date</label><div class="date-wrap"><input type="date" id="f-closedate"><button type="button" class="cal-btn" onclick="document.getElementById('f-closedate').showPicker()" title="Pick date">&#128197;</button></div></div>
     </div>
     <div style="padding:0 20px 20px;display:grid;grid-template-columns:1fr auto;gap:12px;align-items:end">
       <div></div>

--- a/src/js/core/03-form-controls.js
+++ b/src/js/core/03-form-controls.js
@@ -128,6 +128,8 @@ function setOut(o) {
   // Show close cost field only when CLOSED
   const ccField = document.getElementById('field-closecost');
   if (ccField) ccField.style.display = (o === 'CLOSED') ? '' : 'none';
+  const cdInput = document.getElementById('f-closedate');
+  if (o === 'CLOSED' && cdInput && !cdInput.value) cdInput.value = today();
   autoFillFromLot();
 }
 function refreshLotPicker() {

--- a/src/js/core/04-trade-crud.js
+++ b/src/js/core/04-trade-crud.js
@@ -18,7 +18,7 @@ function addTrade() {
 }
 
 function clearForm() {
-  ['f-strike','f-dte','f-closecost'].forEach(id => { const el = document.getElementById(id); if (el) el.value = ''; });
+  ['f-strike','f-dte','f-closecost','f-closedate'].forEach(id => { const el = document.getElementById(id); if (el) el.value = ''; });
   document.getElementById('f-size').value = minSize(sAsset);
   document.getElementById('ferr').style.display = 'none';
 }

--- a/src/js/core/05b-pnl.js
+++ b/src/js/core/05b-pnl.js
@@ -59,7 +59,9 @@ function computePnl(trades, assetFilter, livePrices) {
           delta += gain;
         }
       }
-      const evDate = t.expiry || t.date;
+      // Realised on the close date for buy-to-close (may be before expiry —
+      // "closed early"); otherwise on expiry. Falls back to open date.
+      const evDate = (t.outcome === 'CLOSED' && t.closeDate) ? t.closeDate : (t.expiry || t.date);
       events.push({ date: evDate, delta });
       const ym = (evDate || '').slice(0, 7);
       if (ym) realisedByMonth[ym] = (realisedByMonth[ym] || 0) + delta;

--- a/src/js/core/13-edit-modal.js
+++ b/src/js/core/13-edit-modal.js
@@ -50,6 +50,9 @@ function openEditModal(id, presetOutcome) {
     // Buy-to-close cost, netted off premium; only meaningful for CLOSED.
     html += '<div class="field" id="ef-closecost-field"><label>Close Cost ($)</label>'
       + '<input id="ef-closecost" type="number" value="' + (t.closeCost || '') + '" step="0.01" min="0"></div>';
+    // Realisation date for buy-to-close; only meaningful for CLOSED.
+    html += '<div class="field" id="ef-closedate-field"><label>Close Date</label>'
+      + '<input id="ef-closedate" type="date" value="' + (t.closeDate || '') + '"></div>';
     html += '<div class="field" style="grid-column:1/-1"><label>Notes</label><input id="ef-notes" type="text" value="' + (t.notes || '') + '"></div>';
   }
 
@@ -65,8 +68,13 @@ function openEditModal(id, presetOutcome) {
 // Show the Close Cost field only when the selected outcome is CLOSED.
 function toggleEditCloseCost() {
   const sel = document.getElementById('ef-outcome');
-  const field = document.getElementById('ef-closecost-field');
-  if (sel && field) field.style.display = sel.value === 'CLOSED' ? '' : 'none';
+  const show = !!sel && sel.value === 'CLOSED';
+  const ccField = document.getElementById('ef-closecost-field');
+  const cdField = document.getElementById('ef-closedate-field');
+  if (ccField) ccField.style.display = show ? '' : 'none';
+  if (cdField) cdField.style.display = show ? '' : 'none';
+  const cd = document.getElementById('ef-closedate');
+  if (show && cd && !cd.value) cd.value = today();
 }
 
 function closeEditModal() {
@@ -107,8 +115,10 @@ function saveEdit() {
     if (t.outcome === 'CLOSED') {
       const cc = parseFloat(get('closecost').value);
       t.closeCost = isNaN(cc) ? 0 : cc;
+      t.closeDate = get('closedate').value.trim();
     } else {
       t.closeCost = 0;
+      t.closeDate = '';
     }
   }
 

--- a/src/js/tradfi/19-tradfi-form.js
+++ b/src/js/tradfi/19-tradfi-form.js
@@ -42,7 +42,7 @@ function wheelerAddTrade() {
 
   let tradeObj;
   if (sType === 'HOLDING') {
-    tradeObj = { id, asset, type: 'HOLDING', date, expiry: '', dte: null, strike, size, premium: 0, outcome: 'OPEN', closeCost: 0, platform: 'MANUAL' };
+    tradeObj = { id, asset, type: 'HOLDING', date, expiry: '', dte: null, strike, size, premium: 0, outcome: 'OPEN', closeCost: 0, closeDate: '', platform: 'MANUAL' };
   } else {
     const expiry  = g('f-expiry');
     const dte     = parseInt(g('f-dte')) || null;
@@ -50,10 +50,12 @@ function wheelerAddTrade() {
     // Buy-to-close: the amount paid to close the option early, netted off the
     // premium received. Only meaningful for the CLOSED outcome.
     const closeCost = sOut === 'CLOSED' ? (parseFloat(g('f-closecost')) || 0) : 0;
+    // Realisation date for buy-to-close (defaults to today via setOut).
+    const closeDate = sOut === 'CLOSED' ? g('f-closedate') : '';
     if (!expiry) return err('Expiry required.');
     // Options are entered in contracts; store shares so the lot engine (shares)
     // lines up with holdings entered as raw share counts.
-    tradeObj = { id, asset, type: sType, date, expiry, dte, strike, size: contractsToShares(size), premium, outcome: sOut, closeCost, platform: 'MANUAL' };
+    tradeObj = { id, asset, type: sType, date, expiry, dte, strike, size: contractsToShares(size), premium, outcome: sOut, closeCost, closeDate, platform: 'MANUAL' };
   }
 
   trades.push(tradeObj);

--- a/test/unit/pnl.test.js
+++ b/test/unit/pnl.test.js
@@ -216,6 +216,31 @@ test('realisedByMonth: empty when no settled events', () => {
   assert.deepStrictEqual(realisedByMonth, {});
 });
 
+test('closeDate: CLOSED trade buckets realised on closeDate, not expiry', () => {
+  // Opened Jan, expiry March, but bought to close early on 2026-02-10.
+  // netPrem = 120 − 20 = 100, realised on the close date's month (Feb), not expiry (Mar).
+  const trades = [
+    { id: 1, asset: 'BTC', type: 'PUT', date: '2026-01-01', expiry: '2026-03-15',
+      strike: 50000, size: 0.1, premium: 120, outcome: 'CLOSED', closeCost: 20,
+      closeDate: '2026-02-10' },
+  ];
+  const { realised, realisedByMonth, realisedSeries } = computePnl(trades);
+  assert.strictEqual(realised, 100);
+  assert.strictEqual(realisedByMonth['2026-02'], 100);
+  assert.strictEqual(realisedByMonth['2026-03'], undefined);
+  assert.strictEqual(realisedSeries[realisedSeries.length - 1].date, '2026-02-10');
+});
+
+test('closeDate: CLOSED trade with no closeDate falls back to expiry', () => {
+  const trades = [
+    { id: 1, asset: 'BTC', type: 'PUT', date: '2026-01-01', expiry: '2026-03-15',
+      strike: 50000, size: 0.1, premium: 120, outcome: 'CLOSED', closeCost: 20,
+      closeDate: '' },
+  ];
+  const { realisedByMonth } = computePnl(trades);
+  assert.strictEqual(realisedByMonth['2026-03'], 100);
+});
+
 test('realisedByMonth: respects asset filter', () => {
   const trades = [
     { id: 1, asset: 'BTC', type: 'PUT', date: '2026-01-01', expiry: '2026-01-15',


### PR DESCRIPTION
PR 1 of the #123 P&L Calendar work — lands the trade-shape foundation the calendar rides on.

## What
- **`closeDate` trade field** (empty except for CLOSED trades) — the date a buy-to-close was realised, which may be *before* expiry ("closed early").
- **Wheeler form**: Close Date input appears alongside Close Cost when CLOSED is selected; defaults to today, cleared by `clearForm`.
- **Edit modal (shared)**: `ef-closedate` in the CLOSED block, defaults to today when empty, read/written on save, reset when outcome leaves CLOSED.
- **`computePnl` bucketing**: CLOSED realised P&L is now dated on `closeDate` (falls back to `expiry` if unset). Retro-corrects `realisedByMonth` / `realisedSeries` for closed-early positions.

## Notes
- Existing CLOSED trades have no `closeDate` → fall back to expiry (today's behaviour). No migration needed.
- Field is shared (also wired into the crypto edit modal) per design discussion.

## Verification
- `python3 build.py --check` OK for both apps.
- `npm test` 165/165, incl. 2 new close-date bucketing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)