### PR TITLE
Wheeler: drop Total Notional tile + Expiring This Week section

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -97,6 +97,7 @@ body{font-family:var(--mono);background:var(--bg);color:var(--text);font-size:15
 
 /* EXPIRY WATCH */
 .expiry-section{background:var(--surface);border-left:2px solid var(--green);padding:14px 16px 0;margin-bottom:0}
+body[data-app="tradfi"] .expiry-section{display:none}
 #expiry-table-wrap{overflow-x:auto;background:linear-gradient(to right,var(--surface) 20px,transparent) left/40px 100% no-repeat,linear-gradient(to left,var(--surface) 20px,transparent) right/40px 100% no-repeat,radial-gradient(farthest-side at 0% 50%,rgba(0,214,143,.12),transparent) left/8px 100% no-repeat,radial-gradient(farthest-side at 100% 50%,rgba(0,214,143,.12),transparent) right/8px 100% no-repeat;background-attachment:local,local,scroll,scroll}
 .expiry-hd{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
 .expiry-ttl{font-size:.65rem;font-weight:500;letter-spacing:2px;color:var(--green)}

--- a/src/js/core/06-render-table.js
+++ b/src/js/core/06-render-table.js
@@ -249,6 +249,8 @@ function rStats(streams, lots, allRows, displayRows) {
 }
 
 function renderExpiryTable(allRows) {
+  // Wheeler hides the Expiring This Week section (CSS); skip populating it.
+  if (_isTradfi()) return;
   const wrap = document.getElementById('expiry-table-wrap');
   if (!wrap) return;
 

--- a/src/js/core/07-render-charts.js
+++ b/src/js/core/07-render-charts.js
@@ -400,10 +400,10 @@ function rCharts(displayRows, lots) {
         s.totalCount > 0 ? pos(s.settled) + ' settled' + (s.openCount > 0 ? ' · ' + s.openCount + ' open' : '') : '',
         'Sum of every option premium collected (gross of buy-to-close costs). Includes settled and open positions.') +
       '<div class="ppnl-trio">' +
-        tile('', 'Total Notional',
+        (_isTradfi() ? '' : tile('', 'Total Notional',
           s.totalNotional > 0 ? '$' + fmt(s.totalNotional) : dash,
           s.totalCount > 0 ? pos(s.totalCount) + (s.openCount > 0 ? ' · ' + s.openCount + ' open' : '') : '',
-          'Total Notional = Σ strike × size across every option (settled and open). The capital you would tie up if every put were assigned at strike.') +
+          'Total Notional = Σ strike × size across every option (settled and open). The capital you would tie up if every put were assigned at strike.')) +
         tile('', 'Portfolio APR',
           s.portfolioAPR !== null ? s.portfolioAPR.toFixed(1) + '%' : dash,
           s.settled > 0 ? 'notional-weighted · ' + s.settled + ' settled' : '',

--- a/test/integration/wheeler-removals.test.js
+++ b/test/integration/wheeler-removals.test.js
@@ -1,0 +1,48 @@
+// Wheeler-only UI removals: no Total Notional tile, no Expiring This Week table.
+// Both are useful on HyperWheel (crypto) but noise on Wheeler, so they're gated
+// to the crypto app only.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { setupJsdom } = require('../helpers/setupJsdom');
+
+function findCard(window, labelRegex) {
+  for (const c of window.document.querySelectorAll('.ppnl-card')) {
+    const lbl = c.querySelector('.ppnl-lbl');
+    if (lbl && labelRegex.test(lbl.textContent)) return c;
+  }
+  return null;
+}
+
+test('Wheeler Premium tab drops the Total Notional tile; keeps Portfolio APR', async (t) => {
+  const trades = [
+    { id: 1, asset: 'IBIT', type: 'PUT', date: '2026-01-01', expiry: '2026-01-15',
+      dte: 14, strike: 60, size: 100, premium: 120, outcome: 'EXPIRED',
+      closeCost: 0, closeDate: '', platform: 'MANUAL' },
+  ];
+  const { window, teardown } = await setupJsdom({ app: 'tradfi', trades });
+  t.after(teardown);
+
+  assert.strictEqual(findCard(window, /Total Notional/i), null,
+    'Wheeler must not render the Total Notional tile');
+  assert.ok(findCard(window, /Portfolio APR/i),
+    'Portfolio APR tile should still render on Wheeler');
+});
+
+test('Wheeler does not populate the Expiring This Week table', async (t) => {
+  // An option expiring within 7 days would normally fill the table on crypto.
+  const soon = new Date();
+  soon.setDate(soon.getDate() + 3);
+  const expiry = soon.toISOString().slice(0, 10);
+  const trades = [
+    { id: 1, asset: 'IBIT', type: 'PUT', date: '2026-01-01', expiry,
+      dte: 3, strike: 60, size: 100, premium: 120, outcome: 'OPEN',
+      closeCost: 0, closeDate: '', platform: 'MANUAL' },
+  ];
+  const { window, teardown } = await setupJsdom({ app: 'tradfi', trades });
+  t.after(teardown);
+
+  const wrap = window.document.getElementById('expiry-table-wrap');
+  assert.ok(wrap, 'expiry-table-wrap still exists in the shared shell');
+  assert.doesNotMatch(wrap.innerHTML, /IBIT/,
+    'Wheeler must not render expiring rows (section is CSS-hidden)');
+});


### PR DESCRIPTION
PR 2 of the #123 UI revamp — removes two panels that are noise on Wheeler while keeping them on HyperWheel (crypto).

## Changes
- **Total Notional** tile gated out of the Premium tab's supporting trio when `_isTradfi()` (`07-render-charts.js`). Portfolio APR / Return Rate remain.
- **Expiring This Week** section hidden on Wheeler: `renderExpiryTable` early-returns for tradfi (`06-render-table.js`) and the section is CSS-hidden via `body[data-app="tradfi"] .expiry-section{display:none}`.

Both stay fully intact on HyperWheel (short-DTE crypto options genuinely need them).

## Tests
- New `test/integration/wheeler-removals.test.js`: Wheeler drops Total Notional (keeps Portfolio APR); Wheeler doesn't populate the expiring table.
- Existing crypto Total Notional / Expiring This Week tests still pass.
- `build.py --check` + `npm test` (167/167) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)