### PR TITLE
Wheeler: P&L Calendar — monthly realised-P&L heatmap (#123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ Tests mirror this: `test/helpers/assemble.js` does the fragment substitution and
 
 | File | Lines | Key exports / purpose |
 |------|------:|-----------------------|
-| `01-state.js` | 18 | `HW_WALLET_KEY`, `HW_HOLDINGS_KEY`, `HW_SYNCED_KEY`, `trades[]`, `sAsset/sType/sFilter/sPlatform/sSizeUnit/sPpnlTab/sCpnlPeriod`, `sSizeDisplay` (Wheeler contracts↔shares display toggle; crypto ignores it), `sHistOutcome/sHistFrom/sHistTo`, `livePrices{}`, `mergeAsset` |
+| `01-state.js` | 18 | `HW_WALLET_KEY`, `HW_HOLDINGS_KEY`, `HW_SYNCED_KEY`, `trades[]`, `sAsset/sType/sFilter/sPlatform/sSizeUnit/sPpnlTab/sCpnlPeriod`, `sSizeDisplay` (Wheeler contracts↔shares display toggle; crypto ignores it), `sHistOutcome/sHistFrom/sHistTo`, `sCalMonth` (P&L Calendar month, Wheeler; empty → current), `livePrices{}`, `mergeAsset` |
 | `01a-outcomes.js` | 32 | `OUTCOMES` registry: per-outcome `{title, badgeClass, platforms}`. Single source of truth for outcome display data + picker membership. Lot-lifecycle effects live in the Lot Engine, not here |
 | `01b-asset-meta.js` | 24 | `assetColor(sym)` (brand override → stable symbol-hash HSL fallback) and `minSize(sym)` (contract minimum, `0` for unknown tickers). Backed by `ASSET_BRAND`/`ASSET_MIN_SIZE` registries populated by platform modules. Dual-exported. Lets arbitrary tickers work with no config |
 | `02-utils.js` | 33 | `today()`, `save()` (routes trades through the persistence seam `persist()`), `fmt()` (max 2dp), `sk()` (K-abbrev), `loadWallet()`, `saveWallet()`, `toast(msg, kind?)` (`'ok'`/`'err'`/`'info'`). **TradFi contract seam:** `SHARES_PER_CONTRACT` (100), `contractsToShares`/`sharesToContracts` — the single place the ×100 lives (#91); the lot engine works purely in shares. Dual-exports `today/fmt/sk` + the contract helpers for Node tests |
@@ -132,12 +132,13 @@ Tests mirror this: `test/helpers/assemble.js` does the fragment substitution and
 | `04b-lot-engine.js` | 140 | `lotNetCost(costBasis, lotPremiums, size)` and `lotEngine(assetTrades)` → `{lots, portfolioPnl, portfolioPremiums, putOnlyPnl, tradeAccounting}`. **Single source of truth** for wheel invariants (see Lot model below). Pure; dual-exported for Node. **Key invariant:** assigned-PUT premium IS credited to the new lot's `lotPremiums` |
 | `05-compute.js` | 89 | `compute(assetFilter)` → `{streams, lots, allRows, displayRows}`. Cross-asset orchestrator: per-asset grouping, calls `lotEngine`, applies asset filter, sorts, assigns idx, derives display fields (`returnPct`, `monthly`, `annual`, `lotPnl`). Dual-exports `compute` for Node tests (reads `trades`/`lotEngine` from globals — set them before `require`) |
 | `05a-merge-open-lots.js` | 113 | `mergeOpenLots(trades, asset)` → `trades'`. Pure helper that merges all open lots for one asset (size-weighted `costBasis`, summed `lotPremiums`, earliest opener kept, CALL `lotNum` cleared). Prefers `lotEngine`, falls back to `compute` or a HOLDING/ASSIGNED heuristic for Node tests |
-| `05b-pnl.js` | 90 | `computePnl(trades, assetFilter, livePrices)` → `{ realised, unrealised, total, missingSpotAssets, realisedSeries, realisedByMonth }`. Cash-flow-lens P&L calculator. Realised: `Σ settled netPrem + Σ (strike − costBasis) × calledSize` (open contributions are zero). Unrealised: `Σ over open lots of (spot − costBasis) × size`, marked against raw `costBasis` (never `netCost`); assets missing spot are excluded from the sum and reported in `missingSpotAssets`. Total = Realised + Unrealised. HOLDING- and ASSIGNED-originated lots are treated symmetrically in both paths. Pure; dual-exported. ADR: `docs/adr/0003-pnl-cash-flow-lens.md` |
+| `05b-pnl.js` | 90 | `computePnl(trades, assetFilter, livePrices)` → `{ realised, unrealised, total, missingSpotAssets, realisedSeries, realisedByMonth, realisedByDay }`. CLOSED trades are dated on `closeDate` (falls back to expiry); `realisedByDay` is a per-day realised map feeding the P&L Calendar. Cash-flow-lens P&L calculator. Realised: `Σ settled netPrem + Σ (strike − costBasis) × calledSize` (open contributions are zero). Unrealised: `Σ over open lots of (spot − costBasis) × size`, marked against raw `costBasis` (never `netCost`); assets missing spot are excluded from the sum and reported in `missingSpotAssets`. Total = Realised + Unrealised. HOLDING- and ASSIGNED-originated lots are treated symmetrically in both paths. Pure; dual-exported. ADR: `docs/adr/0003-pnl-cash-flow-lens.md` |
 | `05c-outcome-distribution.js` | 32 | `outcomeDistribution(trades, assetFilter)` → `[{outcome, count, premium}]`. Pure helper for the Position History outcome treemap. Excludes OPEN, orders EXPIRED/ASSIGNED/CALLED/CLOSED, nets `closeCost` from CLOSED premium (cash-flow lens). Dual-exported |
 | `06-render-table.js` | 452 | `sortOpen/sortHist`, `renderExpiryTable(allRows)` (today badge + mobile cards — reads enriched rows from `compute`, uses `r.annual` and `_liveDte`; no longer reads raw `trades[]`), `fetchExpiryPrices` (CoinGecko, calls `render()` on success), `rTable` (holdings cards — roster derived from `lots` so arbitrary tickers render, known crypto assets keep brand CSS classes + fixed order, unknown tickers get an inline `assetColor()`; open & history tables, history filter application), `rStats(streams, lots, allRows, displayRows)` (forwards `allRows` to `renderExpiryTable`), `exportHistoryCSV` (downloads filtered history as CSV). `_platCol(cell)`/`_isTradfi()` drop the Platform column/badge when `document.body.dataset.app === 'tradfi'` (Wheeler's single MANUAL platform carries no info). Wheeler open option rows also get a **Close ⊗** quick-action (`btn-qa-cls`) that opens the edit modal preset to CLOSED for buy-to-close |
 | `06a-render-outcome-chart.js` | 75 | `rOutcomeChart()` — renders a horizontal treemap of `outcomeDistribution` into `#hist-outchart` when ≥10 settled trades; otherwise hides itself and shows `#hist-pills`. Each cell click toggles `setHistOutcome`. Cells coloured via CSS vars (EXPIRED/ASSIGNED/CALLED/CLOSED → green/red/orange/blue) |
 | `07-render-charts.js` | 640 | `setCpnlPeriod` (1M/3M/ALL), `rCpnlChart` (cumulative Realised P&L hero — sources `realisedSeries` from `computePnl` — plus secondary Realised sparkline), `rCharts` (Premium P&L total/monthly tabs — Total tab consumes `computePnl` for the Realised tile), `cOpts` (Chart.js options factory) |
-| `08-render.js` | 8 | `render()` — orchestrator: `compute → rStats → rTable → rOutcomeChart → rCharts` |
+| `07b-render-pnl-calendar.js` | ~185 | `pnlCalendar(trades, assetFilter, ym)` (pure, dual-exported) → `{ ym, weeks, weekTotals, monthTotal }`: Sun–Sat grid of per-day realised P&L + `closed`/`new` counts (realised sourced from `computePnl.realisedByDay`; "new" = options opened that day). `rPnlCalendar()` renders it into `#pnl-cal-sec` — **Wheeler only** (self-gates on `_isTradfi()`; CSS hides the section on crypto). `setCalMonth(delta)` shifts `sCalMonth` and re-renders |
+| `08-render.js` | 9 | `render()` — orchestrator: `compute → rStats → rTable → rOutcomeChart → rCharts → rPnlCalendar` |
 | `09-drawer-modal.js` | 15 | `openTradeDrawer`, `closeTradeDrawer`, `focusForm` |
 | `10-reset-modal.js` | 4 | `showReset`, `closeReset`, `doReset` (wipes `trades`) |
 | `11a-asset-brand.js` | 6 | Registers crypto brand colours + Rysk contract minimums as overrides on the core `ASSET_BRAND`/`ASSET_MIN_SIZE` registries (BTC/ETH/HYPE/SOL). Runs at load after `01b-asset-meta.js` |
@@ -348,6 +349,18 @@ CSS vars so adding themes later remains cheap.
   no separate viewer
 
 ---
+
+## Recently added (Aug 2026)
+
+- **P&L Calendar (Wheeler)** (`07b-render-pnl-calendar.js`, #123): monthly
+  heatmap of realised P&L per day + `N closed · N new` activity, weekly-total
+  column, month total and prev/next nav (`sCalMonth`). Realised is dated on the
+  close date for buy-to-close (new `closeDate` trade field) else expiry, via
+  `computePnl.realisedByDay`. Wheeler-only (crypto section CSS-hidden).
+- **`closeDate` trade field** (#123): realisation date for CLOSED (buy-to-close);
+  entered in the Wheeler form + shared edit modal, empty otherwise.
+- **Wheeler UI trims**: Total Notional tile + Expiring This Week section are
+  gated off on Wheeler (kept on HyperWheel).
 
 ## Recently added (May 2026)
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -98,6 +98,40 @@ body{font-family:var(--mono);background:var(--bg);color:var(--text);font-size:15
 /* EXPIRY WATCH */
 .expiry-section{background:var(--surface);border-left:2px solid var(--green);padding:14px 16px 0;margin-bottom:0}
 body[data-app="tradfi"] .expiry-section{display:none}
+
+/* ── P&L Calendar (Wheeler only) ─────────────────────────── */
+body[data-app="crypto"] .pnl-cal-sec{display:none}
+.cal-hd{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:10px;margin-bottom:12px}
+.cal-ttl{display:flex;align-items:center;gap:7px;font-size:.9rem;font-weight:700}
+.cal-nav{display:flex;align-items:center;gap:10px;font-family:var(--mono)}
+.cal-total{font-size:1rem;font-weight:700}
+.cal-total.pos{color:var(--green)}
+.cal-total.neg{color:var(--red)}
+.cal-total.zero{color:var(--mu)}
+.cal-month{min-width:118px;text-align:center;font-size:.8rem;color:var(--text)}
+.cal-navbtn{background:var(--s2);border:1px solid var(--bd2);color:var(--text);border-radius:6px;width:26px;height:26px;cursor:pointer;font-size:1rem;line-height:1;display:flex;align-items:center;justify-content:center}
+.cal-navbtn:hover{border-color:var(--green)}
+.cal-grid{display:grid;grid-template-columns:repeat(7,1fr) .85fr;gap:5px}
+.cal-dow{font-size:.6rem;font-family:var(--mono);color:var(--mu);text-align:center;padding-bottom:2px;letter-spacing:.06em}
+.cal-dow-wk{color:var(--mu2)}
+.cal-cell{min-height:62px;border:1px solid var(--bd);border-radius:7px;background:var(--s2);padding:5px 6px;display:flex;flex-direction:column;gap:2px;overflow:hidden}
+.cal-cell.cal-out{background:transparent;border-color:transparent}
+.cal-cell.pos{background:var(--gd);border-color:var(--gb)}
+.cal-cell.neg{background:var(--rd);border-color:var(--rb)}
+.cal-cell.cal-today{box-shadow:0 0 0 1.5px var(--green) inset}
+.cal-daynum{font-size:.62rem;font-family:var(--mono);color:var(--mu2)}
+.cal-pnl{font-size:.78rem;font-weight:700;font-family:var(--mono)}
+.cal-pnl.pos{color:var(--green)}
+.cal-pnl.neg{color:var(--red)}
+.cal-act{font-size:.56rem;font-family:var(--mono);color:var(--mu);margin-top:auto}
+.cal-week{background:var(--surface);border-style:dashed;justify-content:center}
+@media(max-width:600px){
+  .cal-grid{gap:3px}
+  .cal-cell{min-height:48px;padding:3px 4px}
+  .cal-pnl{font-size:.62rem}
+  .cal-act{font-size:.5rem}
+  .cal-dow{font-size:.5rem}
+}
 #expiry-table-wrap{overflow-x:auto;background:linear-gradient(to right,var(--surface) 20px,transparent) left/40px 100% no-repeat,linear-gradient(to left,var(--surface) 20px,transparent) right/40px 100% no-repeat,radial-gradient(farthest-side at 0% 50%,rgba(0,214,143,.12),transparent) left/8px 100% no-repeat,radial-gradient(farthest-side at 100% 50%,rgba(0,214,143,.12),transparent) right/8px 100% no-repeat;background-attachment:local,local,scroll,scroll}
 .expiry-hd{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
 .expiry-ttl{font-size:.65rem;font-weight:500;letter-spacing:2px;color:var(--green)}

--- a/src/html/body.html
+++ b/src/html/body.html
@@ -79,6 +79,9 @@
     <div id="ppnl-body"></div>
   </div>
 
+  <!-- P&L CALENDAR (Wheeler only; populated by rPnlCalendar) -->
+  <div class="sec pnl-cal-sec" id="pnl-cal-sec"></div>
+
   </div><!-- end top-left -->
 
   <!-- TRADE DRAWER -->

--- a/src/js/core/01-state.js
+++ b/src/js/core/01-state.js
@@ -19,3 +19,7 @@ let mergeAsset = null;
 let sHistOutcome = 'ALL';  // ALL | EXPIRED | ASSIGNED | CALLED | CLOSED
 let sHistFrom = '';        // YYYY-MM-DD or empty
 let sHistTo   = '';
+
+// P&L Calendar displayed month (Wheeler only), 'YYYY-MM'. Empty → current month
+// (lazily set on first render in 07b-render-pnl-calendar.js).
+let sCalMonth = '';

--- a/src/js/core/05b-pnl.js
+++ b/src/js/core/05b-pnl.js
@@ -27,6 +27,7 @@ function computePnl(trades, assetFilter, livePrices) {
   const missingSpotAssets = [];
   const events = [];
   const realisedByMonth = {};
+  const realisedByDay = {};
 
   Object.keys(byAsset).forEach(asset => {
     const assetTrades = byAsset[asset];
@@ -65,6 +66,7 @@ function computePnl(trades, assetFilter, livePrices) {
       events.push({ date: evDate, delta });
       const ym = (evDate || '').slice(0, 7);
       if (ym) realisedByMonth[ym] = (realisedByMonth[ym] || 0) + delta;
+      if (evDate) realisedByDay[evDate] = (realisedByDay[evDate] || 0) + delta;
     });
   });
 
@@ -79,7 +81,7 @@ function computePnl(trades, assetFilter, livePrices) {
   });
 
   const total = realised + unrealised;
-  return { realised, unrealised, total, missingSpotAssets, realisedSeries, realisedByMonth };
+  return { realised, unrealised, total, missingSpotAssets, realisedSeries, realisedByMonth, realisedByDay };
 }
 
 function buildDisplaySeries(series, period, today) {

--- a/src/js/core/07b-render-pnl-calendar.js
+++ b/src/js/core/07b-render-pnl-calendar.js
@@ -1,0 +1,143 @@
+// ── P&L CALENDAR (Wheeler) ────────────────────────────────
+// A monthly heatmap of realised P&L: each day cell shows net realised P&L plus
+// an activity line ("N closed · N new"), a per-week total column, month total and
+// prev/next month navigation. Gated to Wheeler (tradfi) — see rPnlCalendar.
+//
+// Realised P&L is dated on the realisation day (close date for buy-to-close, else
+// expiry) — the same rule computePnl uses, sourced from its realisedByDay map.
+// "New" counts option positions opened that day (bucketed on their open `date`).
+//
+// pnlCalendar() is pure and dual-exported for Node tests.
+
+const CAL_MONTHS = ['January','February','March','April','May','June',
+  'July','August','September','October','November','December'];
+
+// Build the Sun–Sat grid for `ym` ('YYYY-MM') with per-day realised + counts,
+// weekly totals and a month total. Cells outside the month carry no stats.
+function pnlCalendar(trades, assetFilter, ym) {
+  const cp = (typeof computePnl !== 'undefined')
+    ? computePnl
+    : require('./05b-pnl.js').computePnl;
+  const { realisedByDay } = cp(trades, assetFilter, {});
+
+  const filtered = (assetFilter && assetFilter !== 'ALL')
+    ? trades.filter(t => t.asset === assetFilter)
+    : trades;
+
+  // Mirrors the realisation-date rule in 05b-pnl.js.
+  const realDate = t => (t.outcome === 'CLOSED' && t.closeDate)
+    ? t.closeDate : (t.expiry || t.date);
+
+  const closed = {}, opened = {};
+  filtered.forEach(t => {
+    if (t.type === 'HOLDING') return;
+    if (t.date && t.date.slice(0, 7) === ym) opened[t.date] = (opened[t.date] || 0) + 1;
+    if (t.outcome && t.outcome !== 'OPEN') {
+      const d = realDate(t);
+      if (d && d.slice(0, 7) === ym) closed[d] = (closed[d] || 0) + 1;
+    }
+  });
+
+  const [y, m] = ym.split('-').map(Number);
+  const daysInMonth = new Date(Date.UTC(y, m, 0)).getUTCDate();
+  const startDow = new Date(Date.UTC(y, m - 1, 1)).getUTCDay();  // 0=Sun
+
+  const cur = new Date(Date.UTC(y, m - 1, 1 - startDow));
+  const weeks = [], weekTotals = [];
+  let monthTotal = 0;
+  // Enough rows to cover the whole month, padded to full Sun–Sat weeks.
+  const rows = Math.ceil((startDow + daysInMonth) / 7);
+  for (let w = 0; w < rows; w++) {
+    const row = [];
+    let wt = 0;
+    for (let i = 0; i < 7; i++) {
+      const iso = cur.toISOString().slice(0, 10);
+      const inMonth = iso.slice(0, 7) === ym;
+      const cell = { date: iso, inMonth };
+      if (inMonth) {
+        const r = realisedByDay[iso] || 0;
+        cell.realised = r;
+        cell.closed = closed[iso] || 0;
+        cell.new = opened[iso] || 0;
+        wt += r;
+        monthTotal += r;
+      }
+      row.push(cell);
+      cur.setUTCDate(cur.getUTCDate() + 1);
+    }
+    weeks.push(row);
+    weekTotals.push(wt);
+  }
+  return { ym, weeks, weekTotals, monthTotal };
+}
+
+// Signed money label, e.g. +$1,046 / −$62. Whole dollars (calendar cells).
+function _calMoney(n) {
+  const sign = n < 0 ? '−' : '+';
+  return sign + '$' + sk(Math.abs(Math.round(n)));
+}
+
+function rPnlCalendar() {
+  const host = document.getElementById('pnl-cal-sec');
+  if (!host) return;
+  if (!_isTradfi()) { host.innerHTML = ''; return; }
+  if (!sCalMonth) sCalMonth = today().slice(0, 7);
+
+  const { ym, weeks, weekTotals, monthTotal } = pnlCalendar(trades, sFilter, sCalMonth);
+  const [y, m] = ym.split('-').map(Number);
+  const todayIso = today();
+  const totCls = monthTotal > 0 ? 'pos' : monthTotal < 0 ? 'neg' : 'zero';
+
+  let html =
+    '<div class="cal-hd">' +
+      '<div class="cal-ttl"><span class="dot dg"></span>P&amp;L Calendar</div>' +
+      '<div class="cal-nav">' +
+        '<span class="cal-total ' + totCls + '">' + _calMoney(monthTotal) + '</span>' +
+        '<button class="cal-navbtn" onclick="setCalMonth(-1)" title="Previous month">&#8249;</button>' +
+        '<span class="cal-month">' + CAL_MONTHS[m - 1] + ' ' + y + '</span>' +
+        '<button class="cal-navbtn" onclick="setCalMonth(1)" title="Next month">&#8250;</button>' +
+      '</div>' +
+    '</div>';
+
+  html += '<div class="cal-grid">';
+  ['SUN','MON','TUE','WED','THU','FRI','SAT','WEEK'].forEach(d =>
+    html += '<div class="cal-dow' + (d === 'WEEK' ? ' cal-dow-wk' : '') + '">' + d + '</div>');
+
+  weeks.forEach((row, wi) => {
+    row.forEach(cell => {
+      if (!cell.inMonth) { html += '<div class="cal-cell cal-out"></div>'; return; }
+      const dayNum = +cell.date.slice(8, 10);
+      const has = cell.realised !== 0 || cell.closed > 0 || cell.new > 0;
+      const cls = cell.realised > 0 ? 'pos' : cell.realised < 0 ? 'neg' : '';
+      const isToday = cell.date === todayIso;
+      let inner = '<div class="cal-daynum">' + dayNum + '</div>';
+      if (cell.realised !== 0)
+        inner += '<div class="cal-pnl ' + cls + '">' + _calMoney(cell.realised) + '</div>';
+      const bits = [];
+      if (cell.closed > 0) bits.push(cell.closed + ' closed');
+      if (cell.new > 0) bits.push(cell.new + ' new');
+      if (bits.length) inner += '<div class="cal-act">' + bits.join(' · ') + '</div>';
+      html += '<div class="cal-cell ' + (has ? cls : '') + (isToday ? ' cal-today' : '') + '">' + inner + '</div>';
+    });
+    const wt = weekTotals[wi];
+    const wcls = wt > 0 ? 'pos' : wt < 0 ? 'neg' : 'zero';
+    html += '<div class="cal-cell cal-week ' + wcls + '">' +
+      (wt !== 0 ? '<div class="cal-pnl ' + wcls + '">' + _calMoney(wt) + '</div>' : '') +
+      '</div>';
+  });
+  html += '</div>';
+
+  host.innerHTML = html;
+}
+
+// Shift the displayed month by `delta` months and re-render just the calendar.
+function setCalMonth(delta) {
+  if (!sCalMonth) sCalMonth = today().slice(0, 7);
+  const [y, m] = sCalMonth.split('-').map(Number);
+  sCalMonth = new Date(Date.UTC(y, m - 1 + delta, 1)).toISOString().slice(0, 7);
+  rPnlCalendar();
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { pnlCalendar };
+}

--- a/src/js/core/08-render.js
+++ b/src/js/core/08-render.js
@@ -9,4 +9,5 @@ function render() {
   rTable(displayRows, streams, lots);
   rOutcomeChart();
   rCharts(displayRows, lots);
+  rPnlCalendar();  // Wheeler only — self-gates on tradfi
 }

--- a/test/integration/pnl-calendar.test.js
+++ b/test/integration/pnl-calendar.test.js
@@ -1,0 +1,29 @@
+// P&L Calendar renders on Wheeler and is gated off on HyperWheel. Bucketing math
+// is covered by test/unit/pnl-calendar.test.js; this asserts the render wiring.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { setupJsdom } = require('../helpers/setupJsdom');
+
+test('Wheeler renders the P&L Calendar grid + month nav', async (t) => {
+  const { window, teardown } = await setupJsdom({ app: 'tradfi' });
+  t.after(teardown);
+  const sec = window.document.getElementById('pnl-cal-sec');
+  assert.ok(sec, 'calendar container exists');
+  assert.ok(sec.querySelector('.cal-grid'), 'grid rendered');
+  assert.ok(sec.querySelector('.cal-month'), 'month label rendered');
+  // 8 header labels: Sun–Sat + WEEK.
+  assert.strictEqual(sec.querySelectorAll('.cal-dow').length, 8);
+  // Month nav is wired and re-renders without throwing.
+  const before = sec.querySelector('.cal-month').textContent;
+  window.setCalMonth(-1);
+  const after = window.document.querySelector('#pnl-cal-sec .cal-month').textContent;
+  assert.notStrictEqual(after, before, 'prev-month nav changes the label');
+});
+
+test('HyperWheel does not render the P&L Calendar', async (t) => {
+  const { window, teardown } = await setupJsdom({ app: 'crypto' });
+  t.after(teardown);
+  const sec = window.document.getElementById('pnl-cal-sec');
+  assert.ok(sec, 'container still ships in the shared shell');
+  assert.strictEqual(sec.innerHTML, '', 'calendar is empty on crypto');
+});

--- a/test/unit/pnl-calendar.test.js
+++ b/test/unit/pnl-calendar.test.js
@@ -1,0 +1,82 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { pnlCalendar } = require('../../src/js/core/07b-render-pnl-calendar.js');
+const { computePnl } = require('../../src/js/core/05b-pnl.js');
+// pnlCalendar reaches for a global computePnl first; provide it for Node.
+global.computePnl = computePnl;
+global.lotEngine = require('../../src/js/core/04b-lot-engine.js').lotEngine;
+
+// Find the cell for a given ISO date in the built grid.
+function cell(cal, iso) {
+  for (const row of cal.weeks) for (const c of row) if (c.date === iso) return c;
+  return null;
+}
+
+test('grid covers the month with Sun-start full weeks', () => {
+  // August 2026: 1st is a Saturday, 31st is a Monday.
+  const cal = pnlCalendar([], 'ALL', '2026-08');
+  assert.strictEqual(cal.weeks[0][0].date, '2026-07-26', 'first cell is the Sun on/before the 1st');
+  assert.strictEqual(cal.weeks[0][0].inMonth, false);
+  assert.strictEqual(cell(cal, '2026-08-01').inMonth, true);
+  assert.strictEqual(cell(cal, '2026-08-31').inMonth, true);
+  cal.weeks.forEach(w => assert.strictEqual(w.length, 7, 'each week row holds 7 day cells (week total is separate)'));
+});
+
+test('EXPIRED option buckets realised + closed count on its expiry day', () => {
+  const trades = [
+    { id: 1, asset: 'IBIT', type: 'PUT', date: '2026-08-03', expiry: '2026-08-14',
+      strike: 60, size: 100, premium: 226, outcome: 'EXPIRED', closeCost: 0, closeDate: '' },
+  ];
+  const cal = pnlCalendar(trades, 'ALL', '2026-08');
+  const c = cell(cal, '2026-08-14');
+  assert.strictEqual(c.realised, 226);
+  assert.strictEqual(c.closed, 1);
+  assert.strictEqual(cell(cal, '2026-08-03').new, 1, 'opened day gets a "new" count');
+  assert.strictEqual(cal.monthTotal, 226);
+});
+
+test('CLOSED-early option buckets on closeDate, not expiry', () => {
+  const trades = [
+    { id: 1, asset: 'IBIT', type: 'CALL', date: '2026-08-01', expiry: '2026-08-28',
+      strike: 65, size: 100, premium: 100, outcome: 'CLOSED', closeCost: 15, closeDate: '2026-08-11' },
+  ];
+  const cal = pnlCalendar(trades, 'ALL', '2026-08');
+  assert.strictEqual(cell(cal, '2026-08-11').realised, 85, 'realised = 100 − 15 on the close day');
+  assert.strictEqual(cell(cal, '2026-08-11').closed, 1);
+  assert.strictEqual(cell(cal, '2026-08-28').realised, 0, 'nothing lands on expiry');
+});
+
+test('weekTotals and monthTotal agree with computePnl realisedByMonth', () => {
+  const trades = [
+    { id: 1, asset: 'IBIT', type: 'PUT', date: '2026-08-03', expiry: '2026-08-07',
+      strike: 60, size: 100, premium: 100, outcome: 'EXPIRED', closeCost: 0, closeDate: '' },
+    { id: 2, asset: 'IBIT', type: 'PUT', date: '2026-08-10', expiry: '2026-08-14',
+      strike: 58, size: 100, premium: 50, outcome: 'EXPIRED', closeCost: 0, closeDate: '' },
+  ];
+  const cal = pnlCalendar(trades, 'ALL', '2026-08');
+  const sumWeeks = cal.weekTotals.reduce((a, b) => a + b, 0);
+  assert.strictEqual(cal.monthTotal, 150);
+  assert.strictEqual(sumWeeks, 150, 'weekly totals sum to the month total');
+  assert.strictEqual(computePnl(trades).realisedByMonth['2026-08'], cal.monthTotal);
+});
+
+test('asset filter scopes the calendar', () => {
+  const trades = [
+    { id: 1, asset: 'IBIT', type: 'PUT', date: '2026-08-03', expiry: '2026-08-07',
+      strike: 60, size: 100, premium: 100, outcome: 'EXPIRED', closeCost: 0, closeDate: '' },
+    { id: 2, asset: 'SPY', type: 'PUT', date: '2026-08-03', expiry: '2026-08-07',
+      strike: 500, size: 100, premium: 40, outcome: 'EXPIRED', closeCost: 0, closeDate: '' },
+  ];
+  assert.strictEqual(pnlCalendar(trades, 'IBIT', '2026-08').monthTotal, 100);
+  assert.strictEqual(pnlCalendar(trades, 'SPY', '2026-08').monthTotal, 40);
+});
+
+test('HOLDING trades never count as new or closed', () => {
+  const trades = [
+    { id: 1, asset: 'IBIT', type: 'HOLDING', date: '2026-08-05', expiry: '',
+      strike: 60, size: 100, premium: 0, outcome: 'OPEN', closeCost: 0, closeDate: '' },
+  ];
+  const cal = pnlCalendar(trades, 'ALL', '2026-08');
+  assert.strictEqual(cell(cal, '2026-08-05').new, 0);
+  assert.strictEqual(cal.monthTotal, 0);
+});


### PR DESCRIPTION
Closes #123. PR 3 of the revamp — the main feature: a monthly P&L Calendar on Wheeler.

## What it does
- Sun–Sat month grid; each day cell shows net **realised** P&L (green/red tint) + an activity line `N closed · N new`.
- Right-hand **WEEK** column with the week's realised total; **month total** + prev/next nav in the header; today highlighted.
- **Wheeler only** — self-gates on `_isTradfi()`; the section is CSS-hidden on HyperWheel.

## Data decisions (per #123, confirmed)
- Realised is dated on the **realisation day**: `closeDate` for buy-to-close (from PR #127), else expiry — sourced from `computePnl.realisedByDay` (new per-day map, mirrors `realisedByMonth`).
- **"New"** = option positions opened that day (bucketed on `date`); **"closed"** = settled events realised that day. HOLDINGs never count.

## Implementation
- `src/js/core/07b-render-pnl-calendar.js` — pure, dual-exported `pnlCalendar(trades, assetFilter, ym)` → `{weeks, weekTotals, monthTotal}` + `rPnlCalendar()` / `setCalMonth()`.
- `sCalMonth` state; wired into `render()`; container in shared `body.html`; CSS via `:root` vars with a <600px collapse.

## Tests
- `test/unit/pnl-calendar.test.js` — grid shape, day/month bucketing, close-date-early, asset filter, weekly-vs-month total agreement with `computePnl`.
- `test/integration/pnl-calendar.test.js` — renders on Wheeler (grid + nav), absent on HyperWheel.
- `build.py --check` + `npm test` (175/175) green.

Not included (per discussion): the screenshot's activity-cards row and summary tiles — a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)