### PR TITLE
Wheeler: market status header pill; trim GitHub icon + version link from footers

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -55,6 +55,11 @@ body{font-family:var(--mono);background:var(--bg);color:var(--text);font-size:15
 .utc-clock{font-family:var(--mono);font-size:.72rem;color:var(--mu2);letter-spacing:.5px;text-align:right;line-height:1.5;padding-left:16px;border-left:1px solid var(--bd2)}
 .utc-clock .utc-time{font-size:.82rem;font-weight:600;color:var(--text)}
 .utc-clock .utc-date{font-size:.65rem;color:var(--mu2);letter-spacing:1px;text-transform:uppercase}
+.market-badge{font-family:var(--mono);font-size:.6rem;font-weight:700;letter-spacing:.8px;padding:4px 9px;border-radius:999px;text-transform:uppercase;white-space:nowrap;align-self:center;display:inline-flex;align-items:center;gap:5px}
+.market-badge:empty{display:none}
+.market-badge::before{content:'';width:6px;height:6px;border-radius:50%;background:currentColor}
+.market-badge.open{color:var(--green);background:var(--gd);border:1px solid var(--gb)}
+.market-badge.closed{color:var(--orange);background:var(--od);border:1px solid var(--ob)}
 .btn{font-family:var(--mono);font-size:.72rem;font-weight:600;padding:6px 14px;border-radius:0;border:none;cursor:pointer;transition:all .15s;display:inline-flex;align-items:center;gap:6px;letter-spacing:1px}
 .btn-p{background:var(--green);color:var(--bg);border:1px solid var(--green)}.btn-p:hover{background:transparent;color:var(--green)}
 .btn-g{background:transparent;color:var(--mu);border:1px solid var(--bd)}.btn-g:hover{color:var(--green);border-color:rgba(0,214,143,.4)}
@@ -520,13 +525,6 @@ td.td-act { width:1px; white-space:nowrap; padding-right:12px; }
 .footer-live { color: var(--green); }
 .footer-live::before { content: '● '; }
 .footer-sep { color: var(--bd2); }
-.footer-market { font-weight: 700; letter-spacing: .5px; }
-.footer-market:not(:empty)::before { content: '· '; color: var(--bd2); font-weight: 400; }
-.footer-market.open { color: var(--green); }
-.footer-market.closed { color: var(--mu2); }
-.footer-source { margin-left: auto; display: inline-flex; align-items: center; color: var(--mu); transition: color .15s; }
-.footer-source:hover { color: var(--green); }
-.footer-source svg { display: block; }
 
 /* ─── WALLET POPUP ────────────────────────────────────── */
 .wallet-popup {

--- a/src/html/body.html
+++ b/src/html/body.html
@@ -11,6 +11,7 @@
   </div>
   <div class="hbtns" style="display:flex;align-items:center;gap:16px">
 {{FRAG:header_actions}}
+    <span id="market-badge" class="market-badge"></span>
     <div class="utc-clock" id="utc-clock"><div class="utc-time" id="utc-time">--:--:--</div><div class="utc-date" id="utc-date">--- -- --- UTC</div></div>
   </div>
 </header>

--- a/src/html/crypto/footer.html
+++ b/src/html/crypto/footer.html
@@ -6,7 +6,4 @@
   <span class="footer-sep footer-deco">·</span>
   <span id="footer-sync-time">—</span>
   <span class="footer-sep">·</span>
-  <span><a href="https://github.com/heyitsStylez/hyperwheel/releases/tag/{{VERSION_CLEAN}}" target="_blank" rel="noopener">{{VERSION}}</a></span>
-  <span class="footer-sep">·</span>
   <span id="footer-cloud" title="cloud sync" style="min-width:8px;display:inline-block;text-align:center"></span>
-  <a class="footer-source" href="https://github.com/heyitsStylez/hyperwheel" target="_blank" rel="noopener" title="View source on GitHub" aria-label="View source on GitHub"><svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg></a>

--- a/src/html/tradfi/footer.html
+++ b/src/html/tradfi/footer.html
@@ -1,9 +1,5 @@
   <span class="footer-live">LIVE</span>
   <span class="footer-sep footer-deco">·</span>
   <span class="footer-deco">LOCAL</span>
-  <span id="footer-market" class="footer-market"></span>
-  <span class="footer-sep">·</span>
-  <span><a href="https://github.com/heyitsStylez/hyperwheel/releases/tag/{{VERSION_CLEAN}}" target="_blank" rel="noopener">{{VERSION}}</a></span>
   <span class="footer-sep">·</span>
   <span id="footer-cloud" title="cloud sync" style="min-width:8px;display:inline-block;text-align:center"></span>
-  <a class="footer-source" href="https://github.com/heyitsStylez/hyperwheel" target="_blank" rel="noopener" title="View source on GitHub" aria-label="View source on GitHub"><svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg></a>

--- a/src/js/tradfi/18-price-feed.js
+++ b/src/js/tradfi/18-price-feed.js
@@ -90,11 +90,11 @@ async function wheelerFetchPrices() {
   render();
 }
 
-// Paint the footer market-open indicator from sMarketOpen.
+// Paint the header market-open badge from sMarketOpen.
 function wheelerUpdateStatus() {
-  const el = document.getElementById('footer-market');
+  const el = document.getElementById('market-badge');
   if (!el) return;
-  if (sMarketOpen === true)  { el.textContent = 'MARKET OPEN';   el.className = 'footer-market open'; }
-  else if (sMarketOpen === false) { el.textContent = 'MARKET CLOSED'; el.className = 'footer-market closed'; }
-  else { el.textContent = ''; el.className = 'footer-market'; }
+  if (sMarketOpen === true)  { el.textContent = 'MARKET OPEN';   el.className = 'market-badge open'; }
+  else if (sMarketOpen === false) { el.textContent = 'MARKET CLOSED'; el.className = 'market-badge closed'; }
+  else { el.textContent = ''; el.className = 'market-badge'; }
 }

--- a/test/integration/wheeler-price-feed.test.js
+++ b/test/integration/wheeler-price-feed.test.js
@@ -70,7 +70,7 @@ test('market-open indicator reflects Twelve Data is_market_open', async (t) => {
   ]);
   await window.wheelerFetchPrices();
   assert.strictEqual(window.sMarketOpen, true);
-  assert.match(window.document.getElementById('footer-market').textContent, /OPEN/i);
+  assert.match(window.document.getElementById('market-badge').textContent, /OPEN/i);
 
   // Closed
   window.fetch = routedFetch([
@@ -79,7 +79,7 @@ test('market-open indicator reflects Twelve Data is_market_open', async (t) => {
   ]);
   await window.wheelerFetchPrices();
   assert.strictEqual(window.sMarketOpen, false);
-  assert.match(window.document.getElementById('footer-market').textContent, /CLOSED/i);
+  assert.match(window.document.getElementById('market-badge').textContent, /CLOSED/i);
 });
 
 test('both providers down leaves existing prices intact', async (t) => {


### PR DESCRIPTION
## Market status → header pill
Moves the `MARKET OPEN` / `MARKET CLOSED` indicator out of the hard-to-see footer and into a coloured pill beside the header clock:
- Green dot / green pill when open, orange dot / orange pill when closed.
- Empty→hidden on HyperWheel (only Wheeler's price feed populates it).
- Stays visible on mobile, where the clock is CSS-hidden — so it's *more* prominent than the old footer text on phones.

## Footer cleanup (both apps)
- Removed the GitHub source icon (bottom-right) and the version/commit link.
- Wheeler footer is now `LIVE · LOCAL · ⟳`; HyperWheel is `LIVE · wallet · RYSK + HYPERSURFACE · sync-time · ⟳`.
- Dropped the now-orphaned `.footer-market` / `.footer-source` CSS.

Repointed the price-feed test to `#market-badge`. Build + 183 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)