### PR TITLE
Trade Log count matches the table (excludes spot HOLDINGs)

### DIFF
--- a/src/js/core/06-render-table.js
+++ b/src/js/core/06-render-table.js
@@ -434,7 +434,8 @@ function rTable(displayRows, streams, lots) {
     return;
   }
 
-  cntEl.textContent = displayRows.length + ' trade' + (displayRows.length !== 1 ? 's' : '');
+  const logCount = displayRows.filter(r => r.type !== 'HOLDING').length; // open + history; holdings render as cards
+  cntEl.textContent = logCount + ' trade' + (logCount !== 1 ? 's' : '');
 
   // Holdings cards — one card per open lot
   const sym = { BTC:'&#9654;', ETH:'&#9670;', HYPE:'&#9632;', SOL:'&#9679;' };


### PR DESCRIPTION
The top-right Trade Log count read `displayRows.length`, which included spot HOLDINGs — but HOLDINGs render as cards, not table rows. So the header (e.g. "4 trades") disagreed with Open Positions + Position History (e.g. 2 open).

Now it counts non-HOLDING rows (open + history), matching what's actually in the table.

Build + 183 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)