### PR TITLE
Add Edit button to open positions

### DIFF
--- a/src/js/core/06-render-table.js
+++ b/src/js/core/06-render-table.js
@@ -145,6 +145,7 @@ function _openRow(r) {
     + '<td class="' + (isHolding ? 'mu' : 'cr') + '">' + (isHolding ? '&mdash;' : '+$' + fmt(r.premium)) + '</td>'
     + '<td>' + aprStr + '</td>'
     + '<td class="td-act"><div class="row-actions">' + actions
+      + '<button class="btn-qa btn-qa-edit" onclick="openEditModal(' + r.id + ')" title="Edit">Edit</button>'
       + '<button class="btn-d" onclick="deleteTrade(' + r.id + ')" title="Delete">&#10005;</button>'
       + '</div></td>'
     + '</tr>';
@@ -234,6 +235,7 @@ function _openCard(r) {
     +   '<div><span class="exp-card-lbl">APR</span> ' + aprStr + '</div>'
     + '</div>'
     + '<div class="exp-card-row3"><div class="row-actions">' + actions
+    +   '<button class="btn-qa btn-qa-edit" onclick="openEditModal(' + r.id + ')" title="Edit">Edit</button>'
     +   '<button class="btn-d" onclick="deleteTrade(' + r.id + ')" title="Delete">&#10005;</button></div></div>'
     + '</div>';
 }

--- a/test/integration/wheeler-app.test.js
+++ b/test/integration/wheeler-app.test.js
@@ -190,6 +190,22 @@ test('Wheeler open option row shows a Close button; HyperWheel does not', async 
     'HyperWheel closes come from chain-sync — no manual Close button');
 });
 
+test('open positions expose an Edit button (both apps)', async (t) => {
+  const seed = [
+    { id: 7, asset: 'PURR', type: 'CALL', date: '2026-01-05', expiry: '2026-02-05', dte: 31,
+      strike: 65, size: 100, premium: 100, outcome: 'OPEN', closeCost: 0, platform: 'MANUAL' },
+  ];
+  const wheeler = await setupJsdom({ app: 'tradfi', trades: seed });
+  t.after(wheeler.teardown);
+  const openBody = wheeler.window.document.getElementById('ttbody-open').innerHTML;
+  assert.match(openBody, /btn-qa-edit/, 'open row should offer an Edit button');
+  assert.match(openBody, /openEditModal\(7\)/, 'Edit opens the modal with no preset outcome');
+
+  const crypto = await setupJsdom({ app: 'crypto', trades: [{ ...seed[0], id: 8, asset: 'BTC', strike: 90000, size: 0.05, platform: 'RYSK' }] });
+  t.after(crypto.teardown);
+  assert.match(crypto.window.document.getElementById('ttbody-open').innerHTML, /openEditModal\(8\)/);
+});
+
 test('edit modal closes an open option: sets CLOSED + closeCost, nets premium', async (t) => {
   const seed = [
     { id: 7, asset: 'PURR', type: 'CALL', date: '2026-01-05', expiry: '2026-02-05', dte: 31,


### PR DESCRIPTION
Open positions only had quick-outcome / Close / delete actions — there was no way to open the edit modal to correct strike, premium, expiry, or size on an in-flight trade (you'd have to delete and re-add).

Adds an **Edit** button to open positions in both the table rows and the mobile cards, mirroring the existing history rows. The edit modal already handles OPEN trades (the `OUTCOMES` registry includes `OPEN`), so no modal changes were needed — the button was the only missing piece.

New test: `open positions expose an Edit button (both apps)`. Build + 184 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)